### PR TITLE
chore: add security policy files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Security-sensitive files require security team review
+SECURITY.md @cascadeguard/core
+.github/ @cascadeguard/core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via
+[private vulnerability reporting](https://github.com/cascadeguard/cascadeguard/security/advisories/new).
+
+**Do not open public issues for security vulnerabilities.**
+
+### What to expect
+
+- Acknowledgment within 48 hours
+- Status update within 7 days
+- Fix timeline communicated within 14 days
+
+## Security Practices
+
+- All dependencies monitored by Dependabot
+- Secret scanning with push protection enabled
+- Container images signed and include SBOMs where applicable
+- Branch protection enforced on `main`


### PR DESCRIPTION
## Summary

Adds foundational security policy files to the repository:

- **SECURITY.md** — Vulnerability reporting instructions and security practices overview
- **.github/dependabot.yml** — Weekly Dependabot updates for GitHub Actions
- **.github/CODEOWNERS** — Requires `@cascadeguard/core` review for security-sensitive files

## Motivation

Establishes baseline security hygiene: clear disclosure process, automated dependency updates, and code ownership for sensitive paths.