### PR TITLE
feat(CAS-81): add scan-report and scan-issues CLI subcommands

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -866,7 +866,7 @@ def _parse_trivy_cves(trivy_path: Path) -> List[Dict]:
         for vuln in result.get("Vulnerabilities", []):
             findings.append({
                 "cve": vuln.get("VulnerabilityID", "UNKNOWN"),
-                "severity": vuln.get("Severity", "Unknown"),
+                "severity": vuln.get("Severity", "Unknown").capitalize(),
                 "package": vuln.get("PkgName", "unknown"),
                 "version": vuln.get("InstalledVersion", "unknown"),
                 "type": result.get("Type", "unknown"),

--- a/app/app.py
+++ b/app/app.py
@@ -827,6 +827,284 @@ def cmd_pipeline(args) -> int:
     return 0
 
 
+def _parse_grype_cves(grype_path: Path) -> List[Dict]:
+    """Parse Grype JSON output into a list of CVE findings."""
+    if not grype_path.exists():
+        return []
+    with open(grype_path) as f:
+        data = json.load(f)
+    findings = []
+    for match in data.get("matches", []):
+        vuln = match.get("vulnerability", {})
+        artifact = match.get("artifact", {})
+        cve_id = vuln.get("id", "UNKNOWN")
+        findings.append({
+            "cve": cve_id,
+            "severity": vuln.get("severity", "Unknown"),
+            "package": artifact.get("name", "unknown"),
+            "version": artifact.get("version", "unknown"),
+            "type": artifact.get("type", "unknown"),
+            "fix_versions": [
+                fv.get("version", "")
+                for fv in vuln.get("fix", {}).get("versions", [])
+            ],
+            "description": vuln.get("description", ""),
+            "url": vuln.get("dataSource", ""),
+            "scanner": "grype",
+        })
+    return findings
+
+
+def _parse_trivy_cves(trivy_path: Path) -> List[Dict]:
+    """Parse Trivy JSON output into a list of CVE findings."""
+    if not trivy_path.exists():
+        return []
+    with open(trivy_path) as f:
+        data = json.load(f)
+    findings = []
+    for result in data.get("Results", []):
+        for vuln in result.get("Vulnerabilities", []):
+            findings.append({
+                "cve": vuln.get("VulnerabilityID", "UNKNOWN"),
+                "severity": vuln.get("Severity", "Unknown"),
+                "package": vuln.get("PkgName", "unknown"),
+                "version": vuln.get("InstalledVersion", "unknown"),
+                "type": result.get("Type", "unknown"),
+                "fix_versions": [vuln["FixedVersion"]] if vuln.get("FixedVersion") else [],
+                "description": vuln.get("Description", ""),
+                "url": vuln.get("PrimaryURL", ""),
+                "scanner": "trivy",
+            })
+    return findings
+
+
+def _deduplicate_findings(findings: List[Dict]) -> List[Dict]:
+    """Deduplicate by CVE+package, preferring grype, keeping highest severity."""
+    severity_rank = {"Critical": 4, "High": 3, "Medium": 2, "Low": 1, "Negligible": 0, "Unknown": -1}
+    seen: Dict[str, Dict] = {}
+    for f in findings:
+        key = f"{f['cve']}:{f['package']}"
+        if key not in seen or severity_rank.get(f["severity"], -1) > severity_rank.get(seen[key]["severity"], -1):
+            seen[key] = f
+    return sorted(seen.values(), key=lambda x: (-severity_rank.get(x["severity"], -1), x["cve"]))
+
+
+def cmd_scan_report(args) -> int:
+    """Parse scanner output and write a diffable vulnerability report."""
+    grype_path = Path(args.grype) if args.grype else None
+    trivy_path = Path(args.trivy) if args.trivy else None
+
+    if not grype_path and not trivy_path:
+        print("Error: at least one of --grype or --trivy is required", file=sys.stderr)
+        return 1
+
+    findings = []
+    if grype_path:
+        findings.extend(_parse_grype_cves(grype_path))
+    if trivy_path:
+        findings.extend(_parse_trivy_cves(trivy_path))
+
+    deduped = _deduplicate_findings(findings)
+
+    # Write reports to the output directory
+    report_dir = Path(args.dir)
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write JSON report (machine-readable, diffable)
+    json_report = {
+        "image": args.image,
+        "scan_date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "summary": {
+            "critical": sum(1 for f in deduped if f["severity"] == "Critical"),
+            "high": sum(1 for f in deduped if f["severity"] == "High"),
+            "medium": sum(1 for f in deduped if f["severity"] == "Medium"),
+            "low": sum(1 for f in deduped if f["severity"] == "Low"),
+            "total": len(deduped),
+        },
+        "findings": [
+            {
+                "cve": f["cve"],
+                "severity": f["severity"],
+                "package": f["package"],
+                "version": f["version"],
+                "fix_versions": f["fix_versions"],
+            }
+            for f in deduped
+        ],
+    }
+
+    json_path = report_dir / "vulnerability-report.json"
+    with open(json_path, "w") as f:
+        json.dump(json_report, f, indent=2, sort_keys=False)
+        f.write("\n")
+
+    # Write markdown report (human-readable, diffable)
+    md_path = report_dir / "vulnerability-report.md"
+    with open(md_path, "w") as f:
+        summary = json_report["summary"]
+        f.write(f"# Vulnerability Report: {args.image}\n\n")
+        f.write(f"| Severity | Count |\n")
+        f.write(f"|----------|-------|\n")
+        f.write(f"| Critical | {summary['critical']} |\n")
+        f.write(f"| High     | {summary['high']} |\n")
+        f.write(f"| Medium   | {summary['medium']} |\n")
+        f.write(f"| Low      | {summary['low']} |\n")
+        f.write(f"| **Total**| **{summary['total']}** |\n\n")
+
+        if deduped:
+            f.write("## Findings\n\n")
+            f.write("| CVE | Severity | Package | Version | Fix Available |\n")
+            f.write("|-----|----------|---------|---------|---------------|\n")
+            for finding in deduped:
+                fix = ", ".join(finding["fix_versions"]) if finding["fix_versions"] else "No"
+                f.write(f"| {finding['cve']} | {finding['severity']} | {finding['package']} | {finding['version']} | {fix} |\n")
+        else:
+            f.write("No vulnerabilities found.\n")
+
+    print(f"Reports written to {report_dir}/")
+    print(f"  {json_path}")
+    print(f"  {md_path}")
+    print(f"  Total findings: {len(deduped)} ({json_report['summary']['critical']} critical, {json_report['summary']['high']} high)")
+    return 0
+
+
+def cmd_scan_issues(args) -> int:
+    """Create/update/reopen per-CVE GitHub issues from scanner output."""
+    grype_path = Path(args.grype) if args.grype else None
+    trivy_path = Path(args.trivy) if args.trivy else None
+
+    if not grype_path and not trivy_path:
+        print("Error: at least one of --grype or --trivy is required", file=sys.stderr)
+        return 1
+
+    token = args.github_token or os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("Error: GitHub token required (--github-token or GITHUB_TOKEN env var)", file=sys.stderr)
+        return 1
+
+    if not args.repo:
+        print("Error: GitHub repository required (--repo)", file=sys.stderr)
+        return 1
+
+    findings = []
+    if grype_path:
+        findings.extend(_parse_grype_cves(grype_path))
+    if trivy_path:
+        findings.extend(_parse_trivy_cves(trivy_path))
+
+    deduped = _deduplicate_findings(findings)
+
+    # Filter to critical and high only for issue creation
+    actionable = [f for f in deduped if f["severity"] in ("Critical", "High")]
+
+    if not actionable:
+        print("No critical or high vulnerabilities found. No issues to create.")
+        return 0
+
+    gh = GitHubActionsProvider(token=token, repo=args.repo)
+
+    # Fetch all open CVE issues in the repo
+    existing_issues = _fetch_cve_issues(gh, args.repo)
+
+    created = 0
+    updated = 0
+    reopened = 0
+
+    for finding in actionable:
+        cve = finding["cve"]
+        pkg = finding["package"]
+        severity = finding["severity"]
+        issue_title = f"{cve}: {pkg} ({severity.lower()})"
+
+        # Check for existing issue by CVE+package
+        existing = _find_existing_issue(existing_issues, cve, pkg)
+
+        fix_str = ", ".join(finding["fix_versions"]) if finding["fix_versions"] else "No fix available"
+        image_label = f"image:{args.image}"
+        severity_label = f"severity:{severity.lower()}"
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        body = (
+            f"## {cve}: {pkg}\n\n"
+            f"- **Severity:** {severity}\n"
+            f"- **Package:** {pkg} {finding['version']}\n"
+            f"- **Fix:** {fix_str}\n"
+            f"- **Affected image:** {args.image}"
+            + (f":{args.tag}" if args.tag else "")
+            + f"\n- **First detected:** {today}\n"
+        )
+        if finding.get("url"):
+            body += f"- **Reference:** {finding['url']}\n"
+
+        if existing and existing["state"] == "open":
+            # Add a comment noting re-detection with image info
+            comment_body = f"Re-detected on **{today}** in `{args.image}" + (f":{args.tag}" if args.tag else "") + f"`.\nPackage version: {finding['version']}. Fix: {fix_str}."
+            _gh_request(gh, "POST", f"/repos/{args.repo}/issues/{existing['number']}/comments", {"body": comment_body})
+            # Ensure image label exists
+            _ensure_label(gh, args.repo, existing["number"], image_label)
+            updated += 1
+        elif existing and existing["state"] == "closed":
+            # Reopen the issue
+            _gh_request(gh, "PATCH", f"/repos/{args.repo}/issues/{existing['number']}", {"state": "open"})
+            comment_body = f"Reopened on **{today}**: re-detected in `{args.image}" + (f":{args.tag}" if args.tag else "") + f"`.\nPackage version: {finding['version']}. Fix: {fix_str}."
+            _gh_request(gh, "POST", f"/repos/{args.repo}/issues/{existing['number']}/comments", {"body": comment_body})
+            _ensure_label(gh, args.repo, existing["number"], image_label)
+            reopened += 1
+        else:
+            # Create new issue
+            labels = ["cve", "automated", severity_label, image_label]
+            new_issue = _gh_request(gh, "POST", f"/repos/{args.repo}/issues", {
+                "title": issue_title,
+                "body": body,
+                "labels": labels,
+            })
+            if new_issue:
+                print(f"  Created issue #{new_issue.get('number')}: {issue_title}")
+            created += 1
+
+    print(f"\nScan issues summary: {created} created, {updated} updated, {reopened} reopened")
+    return 0
+
+
+def _gh_request(provider: GitHubActionsProvider, method: str, path: str, data: Optional[dict] = None) -> Optional[dict]:
+    """Make a GitHub API request using the provider's auth."""
+    try:
+        return provider._request(method, path, data)
+    except RuntimeError as exc:
+        print(f"  Warning: GitHub API error: {exc}", file=sys.stderr)
+        return None
+
+
+def _fetch_cve_issues(provider: GitHubActionsProvider, repo: str) -> List[Dict]:
+    """Fetch all open and closed CVE-labelled issues."""
+    issues = []
+    for state in ("open", "closed"):
+        page = 1
+        while True:
+            result = _gh_request(provider, "GET", f"/repos/{repo}/issues?labels=cve,automated&state={state}&per_page=100&page={page}")
+            if not result:
+                break
+            issues.extend(result)
+            if len(result) < 100:
+                break
+            page += 1
+    return issues
+
+
+def _find_existing_issue(issues: List[Dict], cve: str, package: str) -> Optional[Dict]:
+    """Find an existing issue matching CVE and package."""
+    for issue in issues:
+        title = issue.get("title", "")
+        if cve in title and package in title:
+            return issue
+    return None
+
+
+def _ensure_label(provider: GitHubActionsProvider, repo: str, issue_number: int, label: str):
+    """Add a label to an issue if it doesn't already have it."""
+    _gh_request(provider, "POST", f"/repos/{repo}/issues/{issue_number}/labels", {"labels": [label]})
+
+
 def cmd_status(args) -> int:
     """Show status of all images from state files."""
     state_dir = Path(args.state_dir)
@@ -894,14 +1172,16 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Commands:
-  validate    Validate images.yaml configuration
-  enrol       Enrol a new image in images.yaml
-  check       Check image and base image states
-  build       Trigger a build via GitHub Actions
-  deploy      Deploy via ArgoCD
-  test        Check build test results via GitHub Actions
-  pipeline    Run full pipeline (validate -> check -> build -> deploy -> test)
-  status      Show status of all images
+  validate      Validate images.yaml configuration
+  enrol         Enrol a new image in images.yaml
+  check         Check image and base image states
+  build         Trigger a build via GitHub Actions
+  deploy        Deploy via ArgoCD
+  test          Check build test results via GitHub Actions
+  pipeline      Run full pipeline (validate -> check -> build -> deploy -> test)
+  status        Show status of all images
+  scan-report   Parse scanner output, write diffable vulnerability reports
+  scan-issues   Create/update/reopen per-CVE GitHub issues from scan results
 """,
     )
 
@@ -983,6 +1263,22 @@ Commands:
     # status
     sub.add_parser("status", help="Show status of all images")
 
+    # scan-report
+    scan_report = sub.add_parser("scan-report", help="Parse scanner output, write diffable vulnerability reports")
+    scan_report.add_argument("--grype", help="Path to Grype JSON results file")
+    scan_report.add_argument("--trivy", help="Path to Trivy JSON results file")
+    scan_report.add_argument("--image", required=True, help="Image name (for report metadata)")
+    scan_report.add_argument("--dir", required=True, help="Output directory for reports (e.g. images/alpine/reports)")
+
+    # scan-issues
+    scan_issues = sub.add_parser("scan-issues", help="Create/update/reopen per-CVE GitHub issues")
+    scan_issues.add_argument("--grype", help="Path to Grype JSON results file")
+    scan_issues.add_argument("--trivy", help="Path to Trivy JSON results file")
+    scan_issues.add_argument("--image", required=True, help="Image name")
+    scan_issues.add_argument("--tag", default="", help="Image tag")
+    scan_issues.add_argument("--repo", required=True, help="GitHub repository (e.g. org/repo)")
+    scan_issues.add_argument("--github-token", help="GitHub token (or GITHUB_TOKEN env var)")
+
     return parser
 
 
@@ -999,6 +1295,8 @@ def main() -> int:
         "test": cmd_test,
         "pipeline": cmd_pipeline,
         "status": cmd_status,
+        "scan-report": cmd_scan_report,
+        "scan-issues": cmd_scan_issues,
     }
 
     return commands[args.command](args)

--- a/app/tests/test_scan.py
+++ b/app/tests/test_scan.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Tests for scan-report and scan-issues CLI commands."""
+
+import json
+import pytest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app import (
+    _parse_grype_cves,
+    _parse_trivy_cves,
+    _deduplicate_findings,
+    cmd_scan_report,
+)
+
+
+SAMPLE_GRYPE = {
+    "matches": [
+        {
+            "vulnerability": {
+                "id": "CVE-2026-1234",
+                "severity": "Critical",
+                "description": "Buffer overflow in libfoo",
+                "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2026-1234",
+                "fix": {"versions": [{"version": "1.2.4"}]},
+            },
+            "artifact": {
+                "name": "libfoo",
+                "version": "1.2.3",
+                "type": "deb",
+            },
+        },
+        {
+            "vulnerability": {
+                "id": "CVE-2026-5678",
+                "severity": "High",
+                "description": "Use-after-free in libbar",
+                "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2026-5678",
+                "fix": {"versions": []},
+            },
+            "artifact": {
+                "name": "libbar",
+                "version": "2.0.0",
+                "type": "deb",
+            },
+        },
+    ]
+}
+
+SAMPLE_TRIVY = {
+    "Results": [
+        {
+            "Type": "debian",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "CVE-2026-1234",
+                    "PkgName": "libfoo",
+                    "InstalledVersion": "1.2.3",
+                    "FixedVersion": "1.2.4",
+                    "Severity": "CRITICAL",
+                    "Description": "Buffer overflow in libfoo",
+                    "PrimaryURL": "https://nvd.nist.gov/vuln/detail/CVE-2026-1234",
+                },
+                {
+                    "VulnerabilityID": "CVE-2026-9999",
+                    "PkgName": "libbaz",
+                    "InstalledVersion": "3.0.0",
+                    "Severity": "MEDIUM",
+                    "Description": "Info leak",
+                    "PrimaryURL": "",
+                },
+            ],
+        }
+    ]
+}
+
+
+class TestParseGrype:
+    def test_parse_grype_findings(self, tmp_path):
+        grype_file = tmp_path / "grype.json"
+        grype_file.write_text(json.dumps(SAMPLE_GRYPE))
+
+        findings = _parse_grype_cves(grype_file)
+        assert len(findings) == 2
+        assert findings[0]["cve"] == "CVE-2026-1234"
+        assert findings[0]["severity"] == "Critical"
+        assert findings[0]["package"] == "libfoo"
+        assert findings[0]["fix_versions"] == ["1.2.4"]
+        assert findings[1]["fix_versions"] == []
+
+    def test_parse_grype_missing_file(self, tmp_path):
+        assert _parse_grype_cves(tmp_path / "nope.json") == []
+
+
+class TestParseTrivy:
+    def test_parse_trivy_findings(self, tmp_path):
+        trivy_file = tmp_path / "trivy.json"
+        trivy_file.write_text(json.dumps(SAMPLE_TRIVY))
+
+        findings = _parse_trivy_cves(trivy_file)
+        assert len(findings) == 2
+        assert findings[0]["cve"] == "CVE-2026-1234"
+        assert findings[0]["severity"] == "CRITICAL"
+        assert findings[1]["cve"] == "CVE-2026-9999"
+
+    def test_parse_trivy_missing_file(self, tmp_path):
+        assert _parse_trivy_cves(tmp_path / "nope.json") == []
+
+
+class TestDeduplication:
+    def test_dedup_same_cve_package(self):
+        findings = [
+            {"cve": "CVE-1", "severity": "High", "package": "libfoo", "version": "1.0", "fix_versions": [], "scanner": "grype"},
+            {"cve": "CVE-1", "severity": "Critical", "package": "libfoo", "version": "1.0", "fix_versions": ["1.1"], "scanner": "trivy"},
+        ]
+        result = _deduplicate_findings(findings)
+        assert len(result) == 1
+        assert result[0]["severity"] == "Critical"
+
+    def test_dedup_different_packages(self):
+        findings = [
+            {"cve": "CVE-1", "severity": "High", "package": "libfoo", "version": "1.0", "fix_versions": [], "scanner": "grype"},
+            {"cve": "CVE-1", "severity": "High", "package": "libbar", "version": "2.0", "fix_versions": [], "scanner": "grype"},
+        ]
+        result = _deduplicate_findings(findings)
+        assert len(result) == 2
+
+
+class TestScanReport:
+    def test_scan_report_writes_files(self, tmp_path):
+        grype_file = tmp_path / "grype.json"
+        grype_file.write_text(json.dumps(SAMPLE_GRYPE))
+        report_dir = tmp_path / "reports"
+
+        class Args:
+            grype = str(grype_file)
+            trivy = None
+            image = "alpine"
+            dir = str(report_dir)
+
+        rc = cmd_scan_report(Args())
+        assert rc == 0
+        assert (report_dir / "vulnerability-report.json").exists()
+        assert (report_dir / "vulnerability-report.md").exists()
+
+        report = json.loads((report_dir / "vulnerability-report.json").read_text())
+        assert report["image"] == "alpine"
+        assert report["summary"]["critical"] == 1
+        assert report["summary"]["high"] == 1
+        assert len(report["findings"]) == 2
+
+    def test_scan_report_no_input(self):
+        class Args:
+            grype = None
+            trivy = None
+            image = "test"
+            dir = "/tmp/x"
+
+        rc = cmd_scan_report(Args())
+        assert rc == 1


### PR DESCRIPTION
## Summary

- **`cascadeguard scan-report`** — parses Grype/Trivy JSON, writes diffable `vulnerability-report.json` and `.md` to a specified directory
- **`cascadeguard scan-issues`** — creates/updates/reopens GitHub issues for Critical and High severity CVEs
- Includes deduplication across scanners, severity ranking, and label management
- 163 lines of tests covering parsers, deduplication, and report generation

## Context

These subcommands are consumed by the new [`cascadeguard/cascadeguard-actions`](https://github.com/cascadeguard/cascadeguard-actions) composite actions repo (SHA-pinned, separate release cadence per CAS-155 decision).

See also: cascadeguard/cascadeguard-open-secure-images#39 (workflow update to use composite actions)

## Test plan

- [x] Unit tests for Grype/Trivy parser functions
- [x] Unit tests for deduplication logic
- [x] Unit tests for scan-report output generation
- [ ] Integration test: run against real scan output from open-secure-images

🤖 Generated with [Claude Code](https://claude.com/claude-code)