### PR TITLE
fix(CAS-178): normalize Trivy severity to title case

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,15 +3,14 @@
 CascadeGuard — container image lifecycle tool.
 
 Commands:
-  validate        Validate images.yaml configuration
-  enrol           Enrol a new image in images.yaml
-  check           Check image and base image states
-  build           Trigger a build via GitHub Actions
-  deploy          Deploy via ArgoCD
-  test            Check build test results via GitHub Actions
-  pipeline        Run full pipeline (validate -> check -> build -> deploy -> test)
-  status          Show status of all images
-  actions pin     Pin GitHub Actions refs to full commit SHAs
+  validate    Validate images.yaml configuration
+  enrol       Enrol a new image in images.yaml
+  check       Check image and base image states
+  build       Trigger a build via GitHub Actions
+  deploy      Deploy via ArgoCD
+  test        Check build test results via GitHub Actions
+  pipeline    Run full pipeline (validate -> check -> build -> deploy -> test)
+  status      Show status of all images
 """
 import argparse
 import json
@@ -451,128 +450,6 @@ class CascadeGuardTool:
 
 
 # ---------------------------------------------------------------------------
-# Actions pinner
-# ---------------------------------------------------------------------------
-
-_SHA_RE = re.compile(r'^[0-9a-f]{40}$')
-# Matches a YAML `uses:` line (with or without leading `- `): captures (prefix, action, ref, trailing)
-_USES_RE = re.compile(r'^(\s*(?:-\s+)?uses:\s+)([^@\n\s]+)@([^\s\n#]+)(.*?)$')
-# Matches any `uses:` line (to detect local/unversioned actions with no `@`)
-_USES_ANY_RE = re.compile(r'^\s*(?:-\s+)?uses:\s+\S')
-
-
-class ActionsPinner:
-    """Pins mutable GitHub Actions refs (tags/branches) to full commit SHAs."""
-
-    def __init__(self, token: str, workflows_dir: Path):
-        self.token = token
-        self.workflows_dir = workflows_dir
-        self._sha_cache: Dict[str, str] = {}
-
-    def _resolve_sha(self, owner_repo: str, ref: str) -> Optional[str]:
-        """Resolve a tag/branch ref to its commit SHA via the GitHub API."""
-        cache_key = f"{owner_repo}@{ref}"
-        if cache_key in self._sha_cache:
-            return self._sha_cache[cache_key]
-
-        url = f"https://api.github.com/repos/{owner_repo}/commits/{ref}"
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-
-        req = urllib.request.Request(url, headers=headers)
-        try:
-            with urllib.request.urlopen(req) as resp:
-                data = json.loads(resp.read())
-                sha = data["sha"]
-                self._sha_cache[cache_key] = sha
-                return sha
-        except (urllib.error.HTTPError, urllib.error.URLError, KeyError):
-            return None
-
-    def pin(self, dry_run: bool = False, update: bool = False) -> Dict:
-        """
-        Pin all mutable action refs in workflow files to commit SHAs.
-
-        Returns a summary dict with keys: pinned, already_pinned, skipped.
-        """
-        pinned = 0
-        already_pinned = 0
-        skipped = 0
-
-        patterns = list(self.workflows_dir.glob("*.yml")) + list(self.workflows_dir.glob("*.yaml"))
-
-        for wf_path in sorted(patterns):
-            original = wf_path.read_text()
-            lines = original.splitlines(keepends=True)
-            new_lines = []
-            changed = False
-
-            for line in lines:
-                m = _USES_RE.match(line)
-                if not m:
-                    # Count `uses:` lines without `@` (e.g. local actions) as skipped
-                    if _USES_ANY_RE.match(line):
-                        skipped += 1
-                    new_lines.append(line)
-                    continue
-
-                prefix, action, ref, trailing = m.groups()
-
-                # Skip local composite actions (relative paths)
-                if action.startswith('./') or '/' not in action:
-                    new_lines.append(line)
-                    skipped += 1
-                    continue
-
-                eol = '\n' if line.endswith('\n') else ''
-
-                if _SHA_RE.match(ref):
-                    # Already pinned to a full SHA
-                    if not update:
-                        new_lines.append(line)
-                        already_pinned += 1
-                        continue
-
-                    # --update: re-pin to latest SHA for the same tag (from trailing comment)
-                    comment_match = re.search(r'#\s*(\S+)', trailing)
-                    if not comment_match:
-                        new_lines.append(line)
-                        already_pinned += 1
-                        continue
-
-                    original_ref = comment_match.group(1)
-                    sha = self._resolve_sha(action, original_ref)
-                    if sha is None or sha == ref:
-                        new_lines.append(line)
-                        already_pinned += 1
-                        continue
-
-                    new_lines.append(f"{prefix}{action}@{sha} # {original_ref}{eol}")
-                    changed = True
-                    pinned += 1
-                else:
-                    # Mutable ref — resolve to SHA
-                    sha = self._resolve_sha(action, ref)
-                    if sha is None:
-                        new_lines.append(line)
-                        skipped += 1
-                        continue
-
-                    new_lines.append(f"{prefix}{action}@{sha} # {ref}{eol}")
-                    changed = True
-                    pinned += 1
-
-            if changed and not dry_run:
-                wf_path.write_text(''.join(new_lines))
-
-        return {"pinned": pinned, "already_pinned": already_pinned, "skipped": skipped}
-
-
-# ---------------------------------------------------------------------------
 # Provider interfaces
 # ---------------------------------------------------------------------------
 
@@ -950,32 +827,282 @@ def cmd_pipeline(args) -> int:
     return 0
 
 
-def cmd_actions_pin(args) -> int:
-    """Pin mutable GitHub Actions refs to full commit SHAs."""
-    token = getattr(args, 'github_token', None) or os.environ.get("GITHUB_TOKEN", "")
-    workflows_dir = Path(args.workflows_dir)
+def _parse_grype_cves(grype_path: Path) -> List[Dict]:
+    """Parse Grype JSON output into a list of CVE findings."""
+    if not grype_path.exists():
+        return []
+    with open(grype_path) as f:
+        data = json.load(f)
+    findings = []
+    for match in data.get("matches", []):
+        vuln = match.get("vulnerability", {})
+        artifact = match.get("artifact", {})
+        cve_id = vuln.get("id", "UNKNOWN")
+        findings.append({
+            "cve": cve_id,
+            "severity": vuln.get("severity", "Unknown"),
+            "package": artifact.get("name", "unknown"),
+            "version": artifact.get("version", "unknown"),
+            "type": artifact.get("type", "unknown"),
+            "fix_versions": [
+                fv.get("version", "")
+                for fv in vuln.get("fix", {}).get("versions", [])
+            ],
+            "description": vuln.get("description", ""),
+            "url": vuln.get("dataSource", ""),
+            "scanner": "grype",
+        })
+    return findings
 
-    if not workflows_dir.exists():
-        print(f"Error: workflows directory not found: {workflows_dir}", file=sys.stderr)
+
+def _parse_trivy_cves(trivy_path: Path) -> List[Dict]:
+    """Parse Trivy JSON output into a list of CVE findings."""
+    if not trivy_path.exists():
+        return []
+    with open(trivy_path) as f:
+        data = json.load(f)
+    findings = []
+    for result in data.get("Results", []):
+        for vuln in result.get("Vulnerabilities", []):
+            findings.append({
+                "cve": vuln.get("VulnerabilityID", "UNKNOWN"),
+                "severity": vuln.get("Severity", "Unknown").capitalize(),
+                "package": vuln.get("PkgName", "unknown"),
+                "version": vuln.get("InstalledVersion", "unknown"),
+                "type": result.get("Type", "unknown"),
+                "fix_versions": [vuln["FixedVersion"]] if vuln.get("FixedVersion") else [],
+                "description": vuln.get("Description", ""),
+                "url": vuln.get("PrimaryURL", ""),
+                "scanner": "trivy",
+            })
+    return findings
+
+
+def _deduplicate_findings(findings: List[Dict]) -> List[Dict]:
+    """Deduplicate by CVE+package, preferring grype, keeping highest severity."""
+    severity_rank = {"Critical": 4, "High": 3, "Medium": 2, "Low": 1, "Negligible": 0, "Unknown": -1}
+    seen: Dict[str, Dict] = {}
+    for f in findings:
+        key = f"{f['cve']}:{f['package']}"
+        if key not in seen or severity_rank.get(f["severity"], -1) > severity_rank.get(seen[key]["severity"], -1):
+            seen[key] = f
+    return sorted(seen.values(), key=lambda x: (-severity_rank.get(x["severity"], -1), x["cve"]))
+
+
+def cmd_scan_report(args) -> int:
+    """Parse scanner output and write a diffable vulnerability report."""
+    grype_path = Path(args.grype) if args.grype else None
+    trivy_path = Path(args.trivy) if args.trivy else None
+
+    if not grype_path and not trivy_path:
+        print("Error: at least one of --grype or --trivy is required", file=sys.stderr)
         return 1
 
-    pinner = ActionsPinner(token=token, workflows_dir=workflows_dir)
-    summary = pinner.pin(dry_run=args.dry_run, update=args.update)
+    findings = []
+    if grype_path:
+        findings.extend(_parse_grype_cves(grype_path))
+    if trivy_path:
+        findings.extend(_parse_trivy_cves(trivy_path))
 
-    pinned = summary["pinned"]
-    already_pinned = summary["already_pinned"]
-    skipped = summary["skipped"]
+    deduped = _deduplicate_findings(findings)
 
-    if args.dry_run:
-        print(f"Dry run — no files written")
+    # Write reports to the output directory
+    report_dir = Path(args.dir)
+    report_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"Actions pinned: {pinned}, already pinned: {already_pinned}, skipped: {skipped}")
+    # Write JSON report (machine-readable, diffable)
+    json_report = {
+        "image": args.image,
+        "scan_date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "summary": {
+            "critical": sum(1 for f in deduped if f["severity"] == "Critical"),
+            "high": sum(1 for f in deduped if f["severity"] == "High"),
+            "medium": sum(1 for f in deduped if f["severity"] == "Medium"),
+            "low": sum(1 for f in deduped if f["severity"] == "Low"),
+            "total": len(deduped),
+        },
+        "findings": [
+            {
+                "cve": f["cve"],
+                "severity": f["severity"],
+                "package": f["package"],
+                "version": f["version"],
+                "fix_versions": f["fix_versions"],
+            }
+            for f in deduped
+        ],
+    }
+
+    json_path = report_dir / "vulnerability-report.json"
+    with open(json_path, "w") as f:
+        json.dump(json_report, f, indent=2, sort_keys=False)
+        f.write("\n")
+
+    # Write markdown report (human-readable, diffable)
+    md_path = report_dir / "vulnerability-report.md"
+    with open(md_path, "w") as f:
+        summary = json_report["summary"]
+        f.write(f"# Vulnerability Report: {args.image}\n\n")
+        f.write(f"| Severity | Count |\n")
+        f.write(f"|----------|-------|\n")
+        f.write(f"| Critical | {summary['critical']} |\n")
+        f.write(f"| High     | {summary['high']} |\n")
+        f.write(f"| Medium   | {summary['medium']} |\n")
+        f.write(f"| Low      | {summary['low']} |\n")
+        f.write(f"| **Total**| **{summary['total']}** |\n\n")
+
+        if deduped:
+            f.write("## Findings\n\n")
+            f.write("| CVE | Severity | Package | Version | Fix Available |\n")
+            f.write("|-----|----------|---------|---------|---------------|\n")
+            for finding in deduped:
+                fix = ", ".join(finding["fix_versions"]) if finding["fix_versions"] else "No"
+                f.write(f"| {finding['cve']} | {finding['severity']} | {finding['package']} | {finding['version']} | {fix} |\n")
+        else:
+            f.write("No vulnerabilities found.\n")
+
+    print(f"Reports written to {report_dir}/")
+    print(f"  {json_path}")
+    print(f"  {md_path}")
+    print(f"  Total findings: {len(deduped)} ({json_report['summary']['critical']} critical, {json_report['summary']['high']} high)")
     return 0
 
 
-def cmd_actions(args) -> int:
-    """Dispatch 'actions' subcommands."""
-    return {"pin": cmd_actions_pin}[args.actions_command](args)
+def cmd_scan_issues(args) -> int:
+    """Create/update/reopen per-CVE GitHub issues from scanner output."""
+    grype_path = Path(args.grype) if args.grype else None
+    trivy_path = Path(args.trivy) if args.trivy else None
+
+    if not grype_path and not trivy_path:
+        print("Error: at least one of --grype or --trivy is required", file=sys.stderr)
+        return 1
+
+    token = args.github_token or os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("Error: GitHub token required (--github-token or GITHUB_TOKEN env var)", file=sys.stderr)
+        return 1
+
+    if not args.repo:
+        print("Error: GitHub repository required (--repo)", file=sys.stderr)
+        return 1
+
+    findings = []
+    if grype_path:
+        findings.extend(_parse_grype_cves(grype_path))
+    if trivy_path:
+        findings.extend(_parse_trivy_cves(trivy_path))
+
+    deduped = _deduplicate_findings(findings)
+
+    # Filter to critical and high only for issue creation
+    actionable = [f for f in deduped if f["severity"] in ("Critical", "High")]
+
+    if not actionable:
+        print("No critical or high vulnerabilities found. No issues to create.")
+        return 0
+
+    gh = GitHubActionsProvider(token=token, repo=args.repo)
+
+    # Fetch all open CVE issues in the repo
+    existing_issues = _fetch_cve_issues(gh, args.repo)
+
+    created = 0
+    updated = 0
+    reopened = 0
+
+    for finding in actionable:
+        cve = finding["cve"]
+        pkg = finding["package"]
+        severity = finding["severity"]
+        issue_title = f"{cve}: {pkg} ({severity.lower()})"
+
+        # Check for existing issue by CVE+package
+        existing = _find_existing_issue(existing_issues, cve, pkg)
+
+        fix_str = ", ".join(finding["fix_versions"]) if finding["fix_versions"] else "No fix available"
+        image_label = f"image:{args.image}"
+        severity_label = f"severity:{severity.lower()}"
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        body = (
+            f"## {cve}: {pkg}\n\n"
+            f"- **Severity:** {severity}\n"
+            f"- **Package:** {pkg} {finding['version']}\n"
+            f"- **Fix:** {fix_str}\n"
+            f"- **Affected image:** {args.image}"
+            + (f":{args.tag}" if args.tag else "")
+            + f"\n- **First detected:** {today}\n"
+        )
+        if finding.get("url"):
+            body += f"- **Reference:** {finding['url']}\n"
+
+        if existing and existing["state"] == "open":
+            # Add a comment noting re-detection with image info
+            comment_body = f"Re-detected on **{today}** in `{args.image}" + (f":{args.tag}" if args.tag else "") + f"`.\nPackage version: {finding['version']}. Fix: {fix_str}."
+            _gh_request(gh, "POST", f"/repos/{args.repo}/issues/{existing['number']}/comments", {"body": comment_body})
+            # Ensure image label exists
+            _ensure_label(gh, args.repo, existing["number"], image_label)
+            updated += 1
+        elif existing and existing["state"] == "closed":
+            # Reopen the issue
+            _gh_request(gh, "PATCH", f"/repos/{args.repo}/issues/{existing['number']}", {"state": "open"})
+            comment_body = f"Reopened on **{today}**: re-detected in `{args.image}" + (f":{args.tag}" if args.tag else "") + f"`.\nPackage version: {finding['version']}. Fix: {fix_str}."
+            _gh_request(gh, "POST", f"/repos/{args.repo}/issues/{existing['number']}/comments", {"body": comment_body})
+            _ensure_label(gh, args.repo, existing["number"], image_label)
+            reopened += 1
+        else:
+            # Create new issue
+            labels = ["cve", "automated", severity_label, image_label]
+            new_issue = _gh_request(gh, "POST", f"/repos/{args.repo}/issues", {
+                "title": issue_title,
+                "body": body,
+                "labels": labels,
+            })
+            if new_issue:
+                print(f"  Created issue #{new_issue.get('number')}: {issue_title}")
+            created += 1
+
+    print(f"\nScan issues summary: {created} created, {updated} updated, {reopened} reopened")
+    return 0
+
+
+def _gh_request(provider: GitHubActionsProvider, method: str, path: str, data: Optional[dict] = None) -> Optional[dict]:
+    """Make a GitHub API request using the provider's auth."""
+    try:
+        return provider._request(method, path, data)
+    except RuntimeError as exc:
+        print(f"  Warning: GitHub API error: {exc}", file=sys.stderr)
+        return None
+
+
+def _fetch_cve_issues(provider: GitHubActionsProvider, repo: str) -> List[Dict]:
+    """Fetch all open and closed CVE-labelled issues."""
+    issues = []
+    for state in ("open", "closed"):
+        page = 1
+        while True:
+            result = _gh_request(provider, "GET", f"/repos/{repo}/issues?labels=cve,automated&state={state}&per_page=100&page={page}")
+            if not result:
+                break
+            issues.extend(result)
+            if len(result) < 100:
+                break
+            page += 1
+    return issues
+
+
+def _find_existing_issue(issues: List[Dict], cve: str, package: str) -> Optional[Dict]:
+    """Find an existing issue matching CVE and package."""
+    for issue in issues:
+        title = issue.get("title", "")
+        if cve in title and package in title:
+            return issue
+    return None
+
+
+def _ensure_label(provider: GitHubActionsProvider, repo: str, issue_number: int, label: str):
+    """Add a label to an issue if it doesn't already have it."""
+    _gh_request(provider, "POST", f"/repos/{repo}/issues/{issue_number}/labels", {"labels": [label]})
 
 
 def cmd_status(args) -> int:
@@ -1045,14 +1172,16 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Commands:
-  validate    Validate images.yaml configuration
-  enrol       Enrol a new image in images.yaml
-  check       Check image and base image states
-  build       Trigger a build via GitHub Actions
-  deploy      Deploy via ArgoCD
-  test        Check build test results via GitHub Actions
-  pipeline    Run full pipeline (validate -> check -> build -> deploy -> test)
-  status      Show status of all images
+  validate      Validate images.yaml configuration
+  enrol         Enrol a new image in images.yaml
+  check         Check image and base image states
+  build         Trigger a build via GitHub Actions
+  deploy        Deploy via ArgoCD
+  test          Check build test results via GitHub Actions
+  pipeline      Run full pipeline (validate -> check -> build -> deploy -> test)
+  status        Show status of all images
+  scan-report   Parse scanner output, write diffable vulnerability reports
+  scan-issues   Create/update/reopen per-CVE GitHub issues from scan results
 """,
     )
 
@@ -1134,34 +1263,21 @@ Commands:
     # status
     sub.add_parser("status", help="Show status of all images")
 
-    # actions
-    actions = sub.add_parser("actions", help="GitHub Actions utilities")
-    actions_sub = actions.add_subparsers(dest="actions_command", metavar="subcommand")
-    actions_sub.required = True
+    # scan-report
+    scan_report = sub.add_parser("scan-report", help="Parse scanner output, write diffable vulnerability reports")
+    scan_report.add_argument("--grype", help="Path to Grype JSON results file")
+    scan_report.add_argument("--trivy", help="Path to Trivy JSON results file")
+    scan_report.add_argument("--image", required=True, help="Image name (for report metadata)")
+    scan_report.add_argument("--dir", required=True, help="Output directory for reports (e.g. images/alpine/reports)")
 
-    actions_pin = actions_sub.add_parser(
-        "pin",
-        help="Pin action refs to full commit SHAs",
-    )
-    actions_pin.add_argument(
-        "--workflows-dir",
-        default=".github/workflows",
-        help="Path to workflows directory (default: .github/workflows)",
-    )
-    actions_pin.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Preview changes without writing files",
-    )
-    actions_pin.add_argument(
-        "--update",
-        action="store_true",
-        help="Re-pin already-pinned SHAs to the latest SHA for the same tag",
-    )
-    actions_pin.add_argument(
-        "--github-token",
-        help="GitHub token (or GITHUB_TOKEN env var)",
-    )
+    # scan-issues
+    scan_issues = sub.add_parser("scan-issues", help="Create/update/reopen per-CVE GitHub issues")
+    scan_issues.add_argument("--grype", help="Path to Grype JSON results file")
+    scan_issues.add_argument("--trivy", help="Path to Trivy JSON results file")
+    scan_issues.add_argument("--image", required=True, help="Image name")
+    scan_issues.add_argument("--tag", default="", help="Image tag")
+    scan_issues.add_argument("--repo", required=True, help="GitHub repository (e.g. org/repo)")
+    scan_issues.add_argument("--github-token", help="GitHub token (or GITHUB_TOKEN env var)")
 
     return parser
 
@@ -1179,7 +1295,8 @@ def main() -> int:
         "test": cmd_test,
         "pipeline": cmd_pipeline,
         "status": cmd_status,
-        "actions": cmd_actions,
+        "scan-report": cmd_scan_report,
+        "scan-issues": cmd_scan_issues,
     }
 
     return commands[args.command](args)

--- a/app/app.py
+++ b/app/app.py
@@ -3,14 +3,15 @@
 CascadeGuard — container image lifecycle tool.
 
 Commands:
-  validate    Validate images.yaml configuration
-  enrol       Enrol a new image in images.yaml
-  check       Check image and base image states
-  build       Trigger a build via GitHub Actions
-  deploy      Deploy via ArgoCD
-  test        Check build test results via GitHub Actions
-  pipeline    Run full pipeline (validate -> check -> build -> deploy -> test)
-  status      Show status of all images
+  validate        Validate images.yaml configuration
+  enrol           Enrol a new image in images.yaml
+  check           Check image and base image states
+  build           Trigger a build via GitHub Actions
+  deploy          Deploy via ArgoCD
+  test            Check build test results via GitHub Actions
+  pipeline        Run full pipeline (validate -> check -> build -> deploy -> test)
+  status          Show status of all images
+  actions pin     Pin GitHub Actions refs to full commit SHAs
 """
 import argparse
 import json
@@ -450,6 +451,128 @@ class CascadeGuardTool:
 
 
 # ---------------------------------------------------------------------------
+# Actions pinner
+# ---------------------------------------------------------------------------
+
+_SHA_RE = re.compile(r'^[0-9a-f]{40}$')
+# Matches a YAML `uses:` line (with or without leading `- `): captures (prefix, action, ref, trailing)
+_USES_RE = re.compile(r'^(\s*(?:-\s+)?uses:\s+)([^@\n\s]+)@([^\s\n#]+)(.*?)$')
+# Matches any `uses:` line (to detect local/unversioned actions with no `@`)
+_USES_ANY_RE = re.compile(r'^\s*(?:-\s+)?uses:\s+\S')
+
+
+class ActionsPinner:
+    """Pins mutable GitHub Actions refs (tags/branches) to full commit SHAs."""
+
+    def __init__(self, token: str, workflows_dir: Path):
+        self.token = token
+        self.workflows_dir = workflows_dir
+        self._sha_cache: Dict[str, str] = {}
+
+    def _resolve_sha(self, owner_repo: str, ref: str) -> Optional[str]:
+        """Resolve a tag/branch ref to its commit SHA via the GitHub API."""
+        cache_key = f"{owner_repo}@{ref}"
+        if cache_key in self._sha_cache:
+            return self._sha_cache[cache_key]
+
+        url = f"https://api.github.com/repos/{owner_repo}/commits/{ref}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                data = json.loads(resp.read())
+                sha = data["sha"]
+                self._sha_cache[cache_key] = sha
+                return sha
+        except (urllib.error.HTTPError, urllib.error.URLError, KeyError):
+            return None
+
+    def pin(self, dry_run: bool = False, update: bool = False) -> Dict:
+        """
+        Pin all mutable action refs in workflow files to commit SHAs.
+
+        Returns a summary dict with keys: pinned, already_pinned, skipped.
+        """
+        pinned = 0
+        already_pinned = 0
+        skipped = 0
+
+        patterns = list(self.workflows_dir.glob("*.yml")) + list(self.workflows_dir.glob("*.yaml"))
+
+        for wf_path in sorted(patterns):
+            original = wf_path.read_text()
+            lines = original.splitlines(keepends=True)
+            new_lines = []
+            changed = False
+
+            for line in lines:
+                m = _USES_RE.match(line)
+                if not m:
+                    # Count `uses:` lines without `@` (e.g. local actions) as skipped
+                    if _USES_ANY_RE.match(line):
+                        skipped += 1
+                    new_lines.append(line)
+                    continue
+
+                prefix, action, ref, trailing = m.groups()
+
+                # Skip local composite actions (relative paths)
+                if action.startswith('./') or '/' not in action:
+                    new_lines.append(line)
+                    skipped += 1
+                    continue
+
+                eol = '\n' if line.endswith('\n') else ''
+
+                if _SHA_RE.match(ref):
+                    # Already pinned to a full SHA
+                    if not update:
+                        new_lines.append(line)
+                        already_pinned += 1
+                        continue
+
+                    # --update: re-pin to latest SHA for the same tag (from trailing comment)
+                    comment_match = re.search(r'#\s*(\S+)', trailing)
+                    if not comment_match:
+                        new_lines.append(line)
+                        already_pinned += 1
+                        continue
+
+                    original_ref = comment_match.group(1)
+                    sha = self._resolve_sha(action, original_ref)
+                    if sha is None or sha == ref:
+                        new_lines.append(line)
+                        already_pinned += 1
+                        continue
+
+                    new_lines.append(f"{prefix}{action}@{sha} # {original_ref}{eol}")
+                    changed = True
+                    pinned += 1
+                else:
+                    # Mutable ref — resolve to SHA
+                    sha = self._resolve_sha(action, ref)
+                    if sha is None:
+                        new_lines.append(line)
+                        skipped += 1
+                        continue
+
+                    new_lines.append(f"{prefix}{action}@{sha} # {ref}{eol}")
+                    changed = True
+                    pinned += 1
+
+            if changed and not dry_run:
+                wf_path.write_text(''.join(new_lines))
+
+        return {"pinned": pinned, "already_pinned": already_pinned, "skipped": skipped}
+
+
+# ---------------------------------------------------------------------------
 # Provider interfaces
 # ---------------------------------------------------------------------------
 
@@ -827,6 +950,34 @@ def cmd_pipeline(args) -> int:
     return 0
 
 
+def cmd_actions_pin(args) -> int:
+    """Pin mutable GitHub Actions refs to full commit SHAs."""
+    token = getattr(args, 'github_token', None) or os.environ.get("GITHUB_TOKEN", "")
+    workflows_dir = Path(args.workflows_dir)
+
+    if not workflows_dir.exists():
+        print(f"Error: workflows directory not found: {workflows_dir}", file=sys.stderr)
+        return 1
+
+    pinner = ActionsPinner(token=token, workflows_dir=workflows_dir)
+    summary = pinner.pin(dry_run=args.dry_run, update=args.update)
+
+    pinned = summary["pinned"]
+    already_pinned = summary["already_pinned"]
+    skipped = summary["skipped"]
+
+    if args.dry_run:
+        print(f"Dry run — no files written")
+
+    print(f"Actions pinned: {pinned}, already pinned: {already_pinned}, skipped: {skipped}")
+    return 0
+
+
+def cmd_actions(args) -> int:
+    """Dispatch 'actions' subcommands."""
+    return {"pin": cmd_actions_pin}[args.actions_command](args)
+
+
 def cmd_status(args) -> int:
     """Show status of all images from state files."""
     state_dir = Path(args.state_dir)
@@ -983,6 +1134,35 @@ Commands:
     # status
     sub.add_parser("status", help="Show status of all images")
 
+    # actions
+    actions = sub.add_parser("actions", help="GitHub Actions utilities")
+    actions_sub = actions.add_subparsers(dest="actions_command", metavar="subcommand")
+    actions_sub.required = True
+
+    actions_pin = actions_sub.add_parser(
+        "pin",
+        help="Pin action refs to full commit SHAs",
+    )
+    actions_pin.add_argument(
+        "--workflows-dir",
+        default=".github/workflows",
+        help="Path to workflows directory (default: .github/workflows)",
+    )
+    actions_pin.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without writing files",
+    )
+    actions_pin.add_argument(
+        "--update",
+        action="store_true",
+        help="Re-pin already-pinned SHAs to the latest SHA for the same tag",
+    )
+    actions_pin.add_argument(
+        "--github-token",
+        help="GitHub token (or GITHUB_TOKEN env var)",
+    )
+
     return parser
 
 
@@ -999,6 +1179,7 @@ def main() -> int:
         "test": cmd_test,
         "pipeline": cmd_pipeline,
         "status": cmd_status,
+        "actions": cmd_actions,
     }
 
     return commands[args.command](args)

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -549,5 +549,200 @@ class TestGenerateBuildWorkflow:
         assert result2 is False
 
 
+class TestActionsPinner:
+    """Unit tests for ActionsPinner."""
+
+    @pytest.fixture
+    def workflows_dir(self):
+        with TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def _write_workflow(self, workflows_dir, name, content):
+        p = workflows_dir / name
+        p.write_text(content)
+        return p
+
+    def test_pin_mutable_tag(self, workflows_dir):
+        """Mutable tag refs are replaced with SHA + comment."""
+        from app import ActionsPinner
+
+        wf = self._write_workflow(workflows_dir, "ci.yml", (
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+        ))
+
+        fake_sha = "a" * 40
+
+        def fake_resolve(owner_repo, ref):
+            assert owner_repo == "actions/checkout"
+            assert ref == "v4"
+            return fake_sha
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = fake_resolve
+
+        summary = pinner.pin()
+        assert summary["pinned"] == 1
+        assert summary["already_pinned"] == 0
+        assert summary["skipped"] == 0
+
+        content = wf.read_text()
+        assert f"actions/checkout@{fake_sha} # v4" in content
+
+    def test_already_pinned_skipped_without_update(self, workflows_dir):
+        """Lines already pinned to a SHA are counted as already_pinned."""
+        from app import ActionsPinner
+
+        sha = "b" * 40
+        wf = self._write_workflow(workflows_dir, "ci.yml", (
+            "      - uses: actions/checkout@" + sha + " # v4\n"
+        ))
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        summary = pinner.pin(update=False)
+
+        assert summary["already_pinned"] == 1
+        assert summary["pinned"] == 0
+        # File unchanged
+        assert sha in wf.read_text()
+
+    def test_update_flag_repins_to_latest_sha(self, workflows_dir):
+        """--update re-pins already-pinned SHAs to the latest SHA for the same tag."""
+        from app import ActionsPinner
+
+        old_sha = "c" * 40
+        new_sha = "d" * 40
+
+        wf = self._write_workflow(workflows_dir, "ci.yml",
+            f"      - uses: actions/checkout@{old_sha} # v4\n"
+        )
+
+        def fake_resolve(owner_repo, ref):
+            assert ref == "v4"
+            return new_sha
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = fake_resolve
+
+        summary = pinner.pin(update=True)
+        assert summary["pinned"] == 1
+
+        content = wf.read_text()
+        assert new_sha in content
+        assert old_sha not in content
+        assert "# v4" in content
+
+    def test_dry_run_does_not_write(self, workflows_dir):
+        """--dry-run previews without writing."""
+        from app import ActionsPinner
+
+        original = "      - uses: actions/checkout@v4\n"
+        wf = self._write_workflow(workflows_dir, "ci.yml", original)
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = lambda owner_repo, ref: "e" * 40
+
+        summary = pinner.pin(dry_run=True)
+        assert summary["pinned"] == 1
+        # File unchanged
+        assert wf.read_text() == original
+
+    def test_local_action_skipped(self, workflows_dir):
+        """Local composite actions (./path) are skipped."""
+        from app import ActionsPinner
+
+        self._write_workflow(workflows_dir, "ci.yml",
+            "      - uses: ./.github/actions/my-action\n"
+        )
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        summary = pinner.pin()
+
+        assert summary["skipped"] == 1
+        assert summary["pinned"] == 0
+
+    def test_api_failure_skips_ref(self, workflows_dir):
+        """When GitHub API fails, the ref is counted as skipped and line unchanged."""
+        from app import ActionsPinner
+
+        original = "      - uses: actions/checkout@v4\n"
+        wf = self._write_workflow(workflows_dir, "ci.yml", original)
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = lambda owner_repo, ref: None  # simulate failure
+
+        summary = pinner.pin()
+        assert summary["skipped"] == 1
+        assert summary["pinned"] == 0
+        assert wf.read_text() == original
+
+    def test_multiple_actions_in_workflow(self, workflows_dir):
+        """Multiple uses: lines are all processed."""
+        from app import ActionsPinner
+
+        sha1 = "1" * 40
+        sha2 = "2" * 40
+        sha3 = "3" * 40
+
+        self._write_workflow(workflows_dir, "ci.yml", (
+            "      - uses: actions/checkout@v4\n"
+            "      - uses: actions/setup-python@v5\n"
+            "      - uses: actions/upload-artifact@v4\n"
+        ))
+
+        shas = {"actions/checkout": sha1, "actions/setup-python": sha2, "actions/upload-artifact": sha3}
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = lambda owner_repo, ref: shas[owner_repo]
+
+        summary = pinner.pin()
+        assert summary["pinned"] == 3
+
+    def test_sha_cache_avoids_duplicate_api_calls(self, workflows_dir):
+        """Same action@ref is resolved only once (via internal cache)."""
+        from app import ActionsPinner
+        import urllib.request
+        import unittest.mock as mock
+
+        self._write_workflow(workflows_dir, "ci.yml", (
+            "      - uses: actions/checkout@v4\n"
+            "      - uses: actions/checkout@v4\n"
+        ))
+
+        fake_sha = "f" * 40
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = f'{{"sha": "{fake_sha}"}}'.encode()
+        fake_response.__enter__ = lambda s: s
+        fake_response.__exit__ = mock.MagicMock(return_value=False)
+
+        call_count = {"n": 0}
+        original_urlopen = urllib.request.urlopen
+
+        def counting_urlopen(req, **kwargs):
+            call_count["n"] += 1
+            return fake_response
+
+        pinner = ActionsPinner(token="t", workflows_dir=workflows_dir)
+        with mock.patch("urllib.request.urlopen", side_effect=counting_urlopen):
+            pinner.pin()
+
+        assert call_count["n"] == 1
+
+    def test_cmd_actions_pin_missing_dir(self):
+        """cmd_actions_pin returns 1 when workflows dir does not exist."""
+        from app import cmd_actions_pin
+        import argparse
+
+        args = argparse.Namespace(
+            workflows_dir="/nonexistent/path/.github/workflows",
+            dry_run=False,
+            update=False,
+            github_token=None,
+        )
+        assert cmd_actions_pin(args) == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/acceptance/fixtures/actions-pin/.github/workflows/ci.yml
+++ b/tests/acceptance/fixtures/actions-pin/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/local-lint
+      - uses: github/super-linter@v6

--- a/tests/acceptance/fixtures/actions-pin/.github/workflows/release.yml
+++ b/tests/acceptance/fixtures/actions-pin/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -608,5 +608,158 @@ class TestGenerateCICLI:
         assert (workspace / ".github" / "workflows").is_dir()
 
 
+ACTIONS_PIN_FIXTURE = Path(__file__).parent / "fixtures" / "actions-pin"
+
+
+class TestActionsPinCLI:
+    """Acceptance tests for `cascadeguard actions pin` using a fixture repo."""
+
+    @pytest.fixture
+    def repo(self):
+        """Copy the actions-pin fixture into a temp dir so tests can mutate it."""
+        import shutil
+
+        with TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir) / "repo"
+            shutil.copytree(ACTIONS_PIN_FIXTURE, dest)
+            yield dest
+
+    @staticmethod
+    def _run_actions_pin(repo, extra_args=None):
+        workflows_dir = repo / ".github" / "workflows"
+        cmd = [
+            sys.executable,
+            str(REPO_ROOT / "app" / "app.py"),
+            "actions", "pin",
+            "--workflows-dir", str(workflows_dir),
+        ]
+        if extra_args:
+            cmd.extend(extra_args)
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "GITHUB_TOKEN": ""},
+            cwd=str(repo),
+        )
+
+    def test_dry_run_reports_counts_without_modifying(self, repo):
+        """--dry-run prints summary but leaves files untouched."""
+        wf = repo / ".github" / "workflows" / "ci.yml"
+        original = wf.read_text()
+
+        result = self._run_actions_pin(repo, ["--dry-run"])
+        assert result.returncode == 0, f"Unexpected failure:\n{result.stderr}"
+        assert "Dry run" in result.stdout
+        assert "Actions pinned:" in result.stdout
+
+        # Files must be unchanged
+        assert wf.read_text() == original
+
+    def test_pin_with_mock_resolver(self, repo):
+        """End-to-end pin using ActionsPinner directly on the fixture repo."""
+        sys.path.insert(0, str(REPO_ROOT / "app"))
+        from app import ActionsPinner
+
+        workflows_dir = repo / ".github" / "workflows"
+        sha_map = {
+            "actions/checkout@v4": "a" * 40,
+            "actions/setup-python@v5": "b" * 40,
+            "actions/upload-artifact@v4": "c" * 40,
+            "github/super-linter@v6": "d" * 40,
+            "actions/setup-node@v4": "e" * 40,
+            "softprops/action-gh-release@v2": "f" * 40,
+        }
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = lambda owner_repo, ref: sha_map.get(f"{owner_repo}@{ref}")
+
+        summary = pinner.pin()
+
+        # ci.yml: checkout(x2), setup-python, upload-artifact, super-linter = 5 mutable
+        # release.yml: setup-node, action-gh-release = 2 mutable
+        # Total mutable pinned: 7
+        assert summary["pinned"] == 7
+        # release.yml checkout is already pinned to a SHA
+        assert summary["already_pinned"] == 1
+        # ci.yml has one local action (./.github/actions/local-lint)
+        assert summary["skipped"] == 1
+
+        # Verify ci.yml content
+        ci_content = (workflows_dir / "ci.yml").read_text()
+        assert f"actions/checkout@{'a' * 40} # v4" in ci_content
+        assert f"actions/setup-python@{'b' * 40} # v5" in ci_content
+        assert f"actions/upload-artifact@{'c' * 40} # v4" in ci_content
+        assert f"github/super-linter@{'d' * 40} # v6" in ci_content
+        # Local action untouched
+        assert "./.github/actions/local-lint" in ci_content
+
+        # Verify release.yml content
+        release_content = (workflows_dir / "release.yml").read_text()
+        assert f"actions/setup-node@{'e' * 40} # v4" in release_content
+        assert f"softprops/action-gh-release@{'f' * 40} # v2" in release_content
+        # Already-pinned checkout SHA preserved (no update flag)
+        assert "b4ffde65f46336ab88eb53be808477a3936bae11" in release_content
+
+    def test_update_repins_existing_sha(self, repo):
+        """--update re-resolves already-pinned SHAs to the latest for their tag."""
+        sys.path.insert(0, str(REPO_ROOT / "app"))
+        from app import ActionsPinner
+
+        workflows_dir = repo / ".github" / "workflows"
+        new_checkout_sha = "1" * 40
+
+        def resolve(owner_repo, ref):
+            if owner_repo == "actions/checkout" and ref == "v4":
+                return new_checkout_sha
+            return None
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = resolve
+
+        summary = pinner.pin(update=True)
+
+        # The already-pinned checkout in release.yml should be re-pinned
+        release_content = (workflows_dir / "release.yml").read_text()
+        assert f"actions/checkout@{new_checkout_sha} # v4" in release_content
+        assert "b4ffde65f46336ab88eb53be808477a3936bae11" not in release_content
+
+    def test_idempotent_second_pin(self, repo):
+        """Pinning twice without --update reports all as already_pinned."""
+        sys.path.insert(0, str(REPO_ROOT / "app"))
+        from app import ActionsPinner
+
+        workflows_dir = repo / ".github" / "workflows"
+
+        pinner = ActionsPinner(token="", workflows_dir=workflows_dir)
+        pinner._resolve_sha = lambda owner_repo, ref: "a" * 40
+
+        # First pass — pin everything
+        pinner.pin()
+
+        # Second pass — all should be already_pinned
+        pinner2 = ActionsPinner(token="", workflows_dir=workflows_dir)
+        summary = pinner2.pin(update=False)
+
+        assert summary["pinned"] == 0
+        assert summary["already_pinned"] >= 7
+        assert summary["skipped"] >= 1
+
+    def test_missing_workflows_dir_exits_nonzero(self):
+        """CLI exits non-zero when the workflows directory does not exist."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "app" / "app.py"),
+                "actions", "pin",
+                "--workflows-dir", "/nonexistent/.github/workflows",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower() or "error" in result.stderr.lower()
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Closing — fix was incorrectly based on CAS-103 branch. The Trivy severity normalization fix has been pushed directly to the CAS-81/scan-cli-subcommands branch (the correct feature branch) as commit 617b757.