### PR TITLE
fix(ci): update stale branch ref in enforce-actions-policy workflow

### DIFF
--- a/.github/workflows/enforce-actions-policy.yaml
+++ b/.github/workflows/enforce-actions-policy.yaml
@@ -37,11 +37,11 @@ jobs:
           python-version: "3.12"
 
       - name: Install CascadeGuard
-        # Install from CAS-105 branch until the actions audit subcommand is
-        # published to PyPI. Switch to `pip install cascadeguard` once released.
+        # Install from main until the actions audit subcommand is published
+        # to PyPI. Switch to `pip install cascadeguard` once released.
         run: |
           pip install --quiet \
-            "git+https://github.com/cascadeguard/cascadeguard.git@CAS-105/actions-policy-schema-and-audit#subdirectory=app"
+            "git+https://github.com/cascadeguard/cascadeguard.git@main#subdirectory=app"
 
       - name: Audit GitHub Actions policy
         run: |


### PR DESCRIPTION
## Summary

- Fix CI failure on enforce-actions-policy workflow caused by deleted branch ref
- The `CAS-105/actions-policy-schema-and-audit` branch was removed after merge to main (PR #52), breaking `pip install` in the workflow
- Updates git install ref from deleted feature branch to `main`

## Test plan

- [ ] Verify CI passes on this PR (the workflow self-tests by running on workflow file changes)
- [ ] Confirm PR #56 CI unblocks after this merges

Fixes CAS-253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)