### PR TITLE
feat(cli): fix images enrol flag placement and add --auto-rebuild

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -772,6 +772,9 @@ def cmd_enrol(args) -> int:
     if args.rebuild_delay:
         new_image["rebuildDelay"] = args.rebuild_delay
 
+    if args.auto_rebuild:
+        new_image["autoRebuild"] = True
+
     images.append(new_image)
 
     with open(images_yaml, "w") as f:
@@ -1532,6 +1535,17 @@ Commands:
     images_enrol.add_argument("--dockerfile", help="Path to Dockerfile in source repo")
     images_enrol.add_argument("--branch", help="Source branch (default: main)")
     images_enrol.add_argument("--rebuild-delay", help="Rebuild delay (e.g. 7d)")
+    images_enrol.add_argument(
+        "--images-yaml",
+        default="images.yaml",
+        help="Path to images.yaml (default: images.yaml)",
+    )
+    images_enrol.add_argument(
+        "--auto-rebuild",
+        action="store_true",
+        default=False,
+        help="Set autoRebuild: true in the generated images.yaml entry",
+    )
 
     # images check
     images_sub.add_parser("check", help="Check image and base image states")

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -49,6 +49,7 @@ def _args(**kwargs):
         dockerfile=None,
         branch=None,
         rebuild_delay=None,
+        auto_rebuild=False,
         image=None,
     )
     defaults.update(kwargs)
@@ -227,6 +228,36 @@ class TestCmdEnrol:
             images = yaml.safe_load(fh)
         assert len(images) == 2
         assert images[1]["name"] == "second"
+
+    def test_enrol_auto_rebuild_flag(self, tmp_path):
+        f = tmp_path / "images.yaml"
+        rc = cmd_enrol(
+            _args(
+                images_yaml=str(f),
+                name="app",
+                registry="ghcr.io",
+                repository="org/app",
+                auto_rebuild=True,
+            )
+        )
+        assert rc == 0
+        with open(f) as fh:
+            images = yaml.safe_load(fh)
+        assert images[0]["autoRebuild"] is True
+
+    def test_enrol_auto_rebuild_false_by_default(self, tmp_path):
+        f = tmp_path / "images.yaml"
+        cmd_enrol(
+            _args(
+                images_yaml=str(f),
+                name="app",
+                registry="ghcr.io",
+                repository="org/app",
+            )
+        )
+        with open(f) as fh:
+            images = yaml.safe_load(fh)
+        assert "autoRebuild" not in images[0]
 
 
 # ---------------------------------------------------------------------------
@@ -575,6 +606,49 @@ class TestParser:
         parser = build_parser()
         args = parser.parse_args(["images", "--images-yaml", "/tmp/custom.yaml", "validate"])
         assert args.images_yaml == "/tmp/custom.yaml"
+
+    def test_images_enrol_images_yaml_after_subcommand(self):
+        """CAS-267: --images-yaml must be usable after `enrol` subcommand."""
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "images",
+                "enrol",
+                "--images-yaml", "/tmp/custom.yaml",
+                "--name", "myapp",
+                "--registry", "ghcr.io",
+                "--repository", "org/myapp",
+            ]
+        )
+        assert args.images_yaml == "/tmp/custom.yaml"
+
+    def test_images_enrol_auto_rebuild_flag(self):
+        """CAS-268: --auto-rebuild flag must be accepted by `images enrol`."""
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "images",
+                "enrol",
+                "--name", "myapp",
+                "--registry", "ghcr.io",
+                "--repository", "org/myapp",
+                "--auto-rebuild",
+            ]
+        )
+        assert args.auto_rebuild is True
+
+    def test_images_enrol_auto_rebuild_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "images",
+                "enrol",
+                "--name", "myapp",
+                "--registry", "ghcr.io",
+                "--repository", "org/myapp",
+            ]
+        )
+        assert args.auto_rebuild is False
 
     def test_state_dir_override(self):
         parser = build_parser()


### PR DESCRIPTION
## Summary

- **CAS-267**: Adds `--images-yaml` to the `images enrol` subparser so users can write `cascadeguard images enrol --images-yaml custom.yaml ...` instead of requiring the flag before the subcommand. The flag was previously only discoverable on the parent `images` command, making it invisible in `enrol --help`.
- **CAS-268**: Adds `--auto-rebuild` flag to `images enrol` that sets `autoRebuild: true` in the generated `images.yaml` entry, enabling a complete CLI-first enrol workflow without manual post-editing.

## Test plan

- [ ] `test_images_enrol_images_yaml_after_subcommand` — verifies `--images-yaml` is accepted after `enrol`
- [ ] `test_images_enrol_auto_rebuild_flag` — verifies `--auto-rebuild` sets flag in parsed args
- [ ] `test_images_enrol_auto_rebuild_default_false` — verifies flag defaults to `False`
- [ ] `test_enrol_auto_rebuild_flag` — verifies `autoRebuild: true` written to images.yaml
- [ ] `test_enrol_auto_rebuild_false_by_default` — verifies `autoRebuild` not written when flag omitted
- [ ] All 47 existing tests still pass

Closes [CAS-267](/CAS/issues/CAS-267) | Closes [CAS-268](/CAS/issues/CAS-268)

Co-Authored-By: Paperclip <noreply@paperclip.ing>