### PR TITLE
fix(ci): update stale branch ref in enforce-actions-policy workflow

### DIFF
--- a/.github/workflows/enforce-actions-policy.yaml
+++ b/.github/workflows/enforce-actions-policy.yaml
@@ -37,11 +37,11 @@ jobs:
           python-version: "3.12"
 
       - name: Install CascadeGuard
-        # Install from CAS-105 branch until the actions audit subcommand is
-        # published to PyPI. Switch to `pip install cascadeguard` once released.
+        # Install from main until the actions audit subcommand is published
+        # to PyPI. Switch to `pip install cascadeguard` once released.
         run: |
           pip install --quiet \
-            "git+https://github.com/cascadeguard/cascadeguard.git@CAS-105/actions-policy-schema-and-audit#subdirectory=app"
+            "git+https://github.com/cascadeguard/cascadeguard.git@main#subdirectory=app"
 
       - name: Audit GitHub Actions policy
         run: |


### PR DESCRIPTION
## Summary

- The `CAS-105/actions-policy-schema-and-audit` branch was deleted after merge (PR #52), causing `pip install` to fail with exit code 1 on all PRs triggering this workflow
- Updated the install ref from the deleted feature branch to `main`

## Test plan

- [ ] CI runs on this PR without pip install failure
- [ ] `enforce-actions-policy` workflow completes successfully

Fixes [CAS-253](/CAS/issues/CAS-253)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>