### PR TITLE
feat(CAS-375): add cascadeguard images check-upstream subcommand

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -7,6 +7,7 @@ Commands:
   images enrol          Enrol a new image in images.yaml
   images check          Check image and base image states
   images status         Show status of all images
+  images check-upstream Query Docker Hub for new upstream tags across enrolled images
   pipeline run          Run full pipeline (validate -> check -> build -> deploy -> test)
   pipeline build        Trigger a build via GitHub Actions
   pipeline deploy       Deploy via ArgoCD
@@ -1393,13 +1394,105 @@ def cmd_actions(args) -> int:
     }[args.actions_command](args)
 
 
+def cmd_images_check_upstream(args) -> int:
+    """Query Docker Hub for new upstream tags across enrolled images."""
+    DOCKER_HUB_TAGS_URL = (
+        "https://hub.docker.com/v2/repositories/{namespace}/{image}"
+        "/tags?page_size=100&ordering=last_updated"
+    )
+
+    def get_dockerhub_tags(namespace: str, image: str) -> List[str]:
+        url = DOCKER_HUB_TAGS_URL.format(namespace=namespace, image=image)
+        tags: List[str] = []
+        page = 0
+        try:
+            while url and page < 10:
+                req = urllib.request.Request(url)
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    data = json.loads(resp.read())
+                tags.extend(t["name"] for t in data.get("results", []))
+                url = data.get("next") or ""
+                page += 1
+        except Exception as exc:
+            logger.warning(f"Could not fetch tags for {namespace}/{image}: {exc}")
+        return tags
+
+    def is_stable_tag(tag: str) -> bool:
+        skip = {"latest", "edge", "nightly", "testing"}
+        if tag in skip:
+            return False
+        for suffix in ("-rc", "-alpha", "-beta", "-dev", "-test", ".rc", "-SNAPSHOT"):
+            if suffix in tag.lower():
+                return False
+        if tag.startswith("sha256:") or len(tag) == 64:
+            return False
+        return True
+
+    images_yaml = Path(args.images_yaml)
+    if not images_yaml.exists():
+        print(f"Error: images.yaml not found: {images_yaml}", file=sys.stderr)
+        return 1
+
+    with open(images_yaml) as f:
+        all_images = yaml.safe_load(f) or []
+
+    if not isinstance(all_images, list):
+        print("Error: images.yaml must be a list", file=sys.stderr)
+        return 1
+
+    if args.image:
+        images_to_check = [img for img in all_images if img.get("name") == args.image]
+        if not images_to_check:
+            print(f"Error: image '{args.image}' not found in images.yaml", file=sys.stderr)
+            return 1
+    else:
+        images_to_check = [img for img in all_images if img.get("enabled", True)]
+
+    findings: List[Dict] = []
+
+    for img in images_to_check:
+        name = img["image"]
+        namespace = img.get("namespace", "library")
+        current_tags: Set[str] = set(img.get("latest_stable_tags", []))
+
+        logger.info(f"Checking {name} (namespace={namespace})")
+        upstream_tags = get_dockerhub_tags(namespace, name)
+        stable_upstream = {t for t in upstream_tags if is_stable_tag(t)}
+
+        new_tags = stable_upstream - current_tags
+        surfaced = []
+        for t in new_tags:
+            base = t.split("-")[0].split(".")[0]
+            if not current_tags or any(
+                c.split("-")[0].split(".")[0] == base for c in current_tags
+            ):
+                surfaced.append(t)
+
+        if surfaced:
+            findings.append({"image": name, "new_tags": sorted(surfaced)})
+
+    has_new = len(findings) > 0
+
+    if args.format == "json":
+        print(json.dumps(findings, indent=2))
+    else:
+        if not findings:
+            print("No new upstream tags detected.")
+        else:
+            for entry in findings:
+                print(f"{entry['image']}: {', '.join(entry['new_tags'])}")
+
+    return 1 if has_new else 0
+
+
 def cmd_images(args) -> int:
     """Dispatch 'images' subcommands."""
     return {
-        "validate": cmd_validate,
-        "enrol":    cmd_enrol,
-        "check":    cmd_check,
-        "status":   cmd_status,
+        "validate":       cmd_validate,
+        "enrol":          cmd_enrol,
+        "check":          cmd_check,
+        "status":         cmd_status,
+        "check-upstream": cmd_images_check_upstream,
     }[args.images_command](args)
 
 
@@ -1552,6 +1645,23 @@ Commands:
 
     # images status
     images_sub.add_parser("status", help="Show status of all images")
+
+    # images check-upstream
+    images_check_upstream = images_sub.add_parser(
+        "check-upstream",
+        help="Query Docker Hub for new upstream tags across enrolled images",
+    )
+    images_check_upstream.add_argument(
+        "--image",
+        default=None,
+        help="Scope check to a single image name (as listed in images.yaml)",
+    )
+    images_check_upstream.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format: table (default) or json",
+    )
 
     # ---------------------------------------------------------------------------
     # pipeline — CI/CD orchestration

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -20,6 +20,7 @@ from app import (
     cmd_check,
     cmd_deploy,
     cmd_enrol,
+    cmd_images_check_upstream,
     cmd_status,
     cmd_test,
     cmd_validate,
@@ -676,6 +677,181 @@ class TestParser:
         args = parser.parse_args(["pipeline", "run"])
         assert args.command == "pipeline"
         assert args.pipeline_command == "run"
+
+
+# ---------------------------------------------------------------------------
+# cmd_images_check_upstream
+# ---------------------------------------------------------------------------
+
+
+def _make_dh_response(tags, next_url=None):
+    """Build a mock Docker Hub tags API response."""
+    body = json.dumps({"results": [{"name": t} for t in tags], "next": next_url}).encode()
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestCmdImagesCheckUpstream:
+
+    def _write_images_yaml(self, tmp_path, images):
+        p = tmp_path / "images.yaml"
+        p.write_text(yaml.dump(images))
+        return str(p)
+
+    def _args(self, images_yaml, image=None, fmt="table"):
+        return SimpleNamespace(images_yaml=images_yaml, image=image, format=fmt)
+
+    # --- no new tags ---
+
+    def test_no_new_tags_returns_0(self, tmp_path):
+        # Upstream returns exactly the enrolled tags — nothing surfaced.
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.28"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    def test_no_new_tags_table_output(self, tmp_path, capsys):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "alpine", "namespace": "library", "latest_stable_tags": ["3.19"], "enabled": True}
+        ])
+        resp = _make_dh_response(["3.19"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            cmd_images_check_upstream(self._args(images_yaml))
+        assert "No new upstream tags" in capsys.readouterr().out
+
+    # --- new tags found ---
+
+    def test_new_tag_returns_1(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 1
+
+    def test_new_tag_json_output(self, tmp_path, capsys):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            cmd_images_check_upstream(self._args(images_yaml, fmt="json"))
+        out = json.loads(capsys.readouterr().out)
+        assert out == [{"image": "nginx", "new_tags": ["1.28"]}]
+
+    def test_new_tag_table_output(self, tmp_path, capsys):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            cmd_images_check_upstream(self._args(images_yaml))
+        assert "nginx: 1.28" in capsys.readouterr().out
+
+    # --- stable-tag filtering ---
+
+    def test_skips_latest(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "latest"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    def test_skips_rc_tags(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28-rc1", "1.28-alpha"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    def test_skips_sha_tags(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        sha = "a" * 64
+        resp = _make_dh_response(["1.27", sha])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    # --- --image scoping ---
+
+    def test_image_filter_scopes_check(self, tmp_path):
+        # --image scopes by the `name` field; only the matching image is queried.
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"name": "nginx", "image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True},
+            {"name": "alpine", "image": "alpine", "namespace": "library", "latest_stable_tags": ["3.19"], "enabled": True},
+        ])
+        # Mock only called once (for nginx); returns only enrolled tag → no new tags.
+        resp = _make_dh_response(["1.27"])
+        with patch("urllib.request.urlopen", return_value=resp) as mock_urlopen:
+            rc = cmd_images_check_upstream(self._args(images_yaml, image="nginx"))
+        mock_urlopen.assert_called_once()
+        assert rc == 0
+
+    def test_image_filter_unknown_name_returns_1(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        rc = cmd_images_check_upstream(self._args(images_yaml, image="nonexistent"))
+        assert rc == 1
+
+    # --- disabled images skipped ---
+
+    def test_disabled_images_skipped(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": False}
+        ])
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        mock_urlopen.assert_not_called()
+        assert rc == 0
+
+    # --- missing images.yaml ---
+
+    def test_missing_images_yaml_returns_1(self, tmp_path):
+        rc = cmd_images_check_upstream(self._args(str(tmp_path / "missing.yaml")))
+        assert rc == 1
+
+    # --- network error is non-fatal ---
+
+    def test_network_error_is_non_fatal(self, tmp_path):
+        import urllib.error
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("timeout")):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0  # no tags surfaced when network fails
+
+    # --- parser wiring ---
+
+    def test_parser_check_upstream_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args(["images", "check-upstream"])
+        assert args.command == "images"
+        assert args.images_command == "check-upstream"
+        assert args.format == "table"
+        assert args.image is None
+
+    def test_parser_check_upstream_with_flags(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["images", "check-upstream", "--format", "json", "--image", "nginx"]
+        )
+        assert args.format == "json"
+        assert args.image == "nginx"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements `cascadeguard images check-upstream` as a first-class CLI subcommand ([CAS-375](/CAS/issues/CAS-375), part 1/3).

- Ports Docker Hub tag-detection logic from inline Python in `check-upstream-tags.yaml`
- Queries Docker Hub v2 API with pagination (up to 10 pages per image)
- Filters stable semver tags (skips `latest`, RC, alpha, nightly, dev, SHA refs)
- Surfaces new tags sharing a version-family prefix with enrolled tags
- `--format json|table` output; `--image <name>` to scope to one image
- Exit code 1 when new tags found (CI-friendly), 0 when none

## Related PRs

- `cascadeguard-actions`: composite action (part 2/3)
- `cascadeguard-open-secure-images`: workflow swap (part 3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)