### PR TITLE
feat(CAS-395): make images check query registry for digest drift

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -785,38 +785,168 @@ def cmd_enrol(args) -> int:
     return 0
 
 
+def _fetch_manifest_digest(registry: str, repository: str, tag: str, token: Optional[str] = None) -> Optional[str]:
+    """
+    Fetch the current manifest digest for registry/repository:tag via the registry v2 API.
+
+    Handles Docker Hub (docker.io) and GHCR (ghcr.io).  Returns the
+    Docker-Content-Digest header value (e.g. 'sha256:abc…') or None when the
+    registry is unreachable or the image/tag does not exist.
+    """
+    ACCEPT = (
+        "application/vnd.docker.distribution.manifest.v2+json,"
+        "application/vnd.oci.image.manifest.v1+json,"
+        "application/vnd.oci.image.index.v1+json,"
+        "application/vnd.docker.distribution.manifest.list.v2+json"
+    )
+
+    def _get_token(auth_url: str, creds: Optional[str] = None) -> str:
+        req = urllib.request.Request(auth_url)
+        if creds:
+            import base64
+            req.add_header("Authorization", f"Basic {base64.b64encode(creds.encode()).decode()}")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+        return data.get("token") or data.get("access_token") or ""
+
+    def _head_manifest(manifest_url: str, bearer: str) -> Optional[str]:
+        req = urllib.request.Request(manifest_url, method="HEAD")
+        req.add_header("Authorization", f"Bearer {bearer}")
+        req.add_header("Accept", ACCEPT)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.headers.get("Docker-Content-Digest")
+
+    try:
+        if registry in ("docker.io", "registry-1.docker.io", "index.docker.io", ""):
+            auth_url = (
+                f"https://auth.docker.io/token"
+                f"?service=registry.docker.io&scope=repository:{repository}:pull"
+            )
+            bearer = _get_token(auth_url)
+            manifest_url = f"https://registry-1.docker.io/v2/{repository}/manifests/{tag}"
+            return _head_manifest(manifest_url, bearer)
+
+        elif registry == "ghcr.io":
+            ghcr_token = token or os.environ.get("GHCR_TOKEN") or os.environ.get("GITHUB_TOKEN")
+            creds = f":{ghcr_token}" if ghcr_token else None
+            auth_url = (
+                f"https://ghcr.io/token"
+                f"?service=ghcr.io&scope=repository:{repository}:pull"
+            )
+            bearer = _get_token(auth_url, creds)
+            manifest_url = f"https://ghcr.io/v2/{repository}/manifests/{tag}"
+            return _head_manifest(manifest_url, bearer)
+
+        else:
+            # Generic registry v2 — attempt anonymous
+            auth_url = (
+                f"https://{registry}/token"
+                f"?service={registry}&scope=repository:{repository}:pull"
+            )
+            bearer = _get_token(auth_url)
+            manifest_url = f"https://{registry}/v2/{repository}/manifests/{tag}"
+            return _head_manifest(manifest_url, bearer)
+
+    except Exception as exc:
+        logger.warning(f"Could not query {registry}/{repository}:{tag}: {exc}")
+        return None
+
+
 def cmd_check(args) -> int:
-    """Check image and base image states from state files."""
+    """Check enrolled images against the live registry for digest drift."""
     state_dir = Path(args.state_dir)
     images_dir = state_dir / "images"
     base_images_dir = state_dir / "base-images"
 
-    if images_dir.exists():
-        print("Application images:")
-        for state_file in sorted(images_dir.glob("*.yaml")):
-            with open(state_file) as f:
-                state = yaml.safe_load(f) or {}
-            name = state.get("name", state_file.stem)
-            digest = state.get("currentDigest") or "null"
-            last_built = state.get("lastBuilt") or "never"
-            status = state.get("discoveryStatus", "unknown")
-            print(f"  {name}: digest={digest} lastBuilt={last_built} status={status}")
-    else:
-        print("No application images found")
+    image_filter: Optional[str] = getattr(args, "image", None)
+    fmt: str = getattr(args, "format", "table")
 
+    results: List[Dict] = []
+
+    # ── Base images ────────────────────────────────────────────────────────────
     if base_images_dir.exists():
-        print("Base images:")
         for state_file in sorted(base_images_dir.glob("*.yaml")):
             with open(state_file) as f:
                 state = yaml.safe_load(f) or {}
             name = state.get("name", state_file.stem)
-            digest = state.get("currentDigest") or "null"
-            last_updated = state.get("lastUpdated") or "never"
-            print(f"  {name}: digest={digest} lastUpdated={last_updated}")
-    else:
-        print("No base images found")
+            if image_filter and name != image_filter:
+                continue
 
-    return 0
+            registry = state.get("registry", "docker.io")
+            repository = state.get("repository", "")
+            tag = str(state.get("tag", "")) if state.get("tag") else ""
+            recorded_digest = state.get("currentDigest") or None
+
+            if not repository or not tag:
+                results.append({"image": name, "status": "skipped", "reason": "no registry coordinates"})
+                continue
+
+            live_digest = _fetch_manifest_digest(registry, repository, tag)
+            if live_digest is None:
+                results.append({"image": name, "status": "error", "reason": "registry unreachable"})
+            elif recorded_digest is None:
+                results.append({"image": name, "status": "unknown", "reason": "no local digest recorded"})
+            elif live_digest == recorded_digest:
+                results.append({"image": name, "status": "ok", "recorded": recorded_digest, "live": live_digest})
+            else:
+                results.append({"image": name, "status": "drift", "recorded": recorded_digest, "live": live_digest})
+
+    # ── Application images ──────────────────────────────────────────────────────
+    if images_dir.exists():
+        for state_file in sorted(images_dir.glob("*.yaml")):
+            with open(state_file) as f:
+                state = yaml.safe_load(f) or {}
+            name = state.get("name", state_file.stem)
+            if image_filter and name != image_filter:
+                continue
+
+            enrollment = state.get("enrollment") or {}
+            registry = enrollment.get("registry", "ghcr.io")
+            repository = enrollment.get("repository", "")
+            tag = str(state.get("currentVersion", "") or "")
+            recorded_digest = state.get("currentDigest") or None
+
+            if not repository or not tag:
+                results.append({"image": name, "status": "skipped", "reason": "no version/tag recorded yet"})
+                continue
+
+            live_digest = _fetch_manifest_digest(registry, repository, tag)
+            if live_digest is None:
+                results.append({"image": name, "status": "error", "reason": "registry unreachable"})
+            elif recorded_digest is None:
+                results.append({"image": name, "status": "unknown", "reason": "no local digest recorded"})
+            elif live_digest == recorded_digest:
+                results.append({"image": name, "status": "ok", "recorded": recorded_digest, "live": live_digest})
+            else:
+                results.append({"image": name, "status": "drift", "recorded": recorded_digest, "live": live_digest})
+
+    if image_filter and not results:
+        print(f"Error: image '{image_filter}' not found in state dir", file=sys.stderr)
+        return 1
+
+    has_drift = any(r["status"] == "drift" for r in results)
+
+    if fmt == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        if not results:
+            print("No enrolled images found.")
+        else:
+            for r in results:
+                status = r["status"]
+                name = r["image"]
+                if status == "ok":
+                    print(f"  {name}: ok ({r['live']})")
+                elif status == "drift":
+                    print(f"  {name}: DRIFT recorded={r['recorded']} live={r['live']}")
+                elif status == "error":
+                    print(f"  {name}: error ({r['reason']})")
+                elif status == "skipped":
+                    print(f"  {name}: skipped ({r['reason']})")
+                elif status == "unknown":
+                    print(f"  {name}: unknown ({r['reason']})")
+
+    return 1 if has_drift else 0
 
 
 def cmd_build(args) -> int:
@@ -1641,7 +1771,21 @@ Commands:
     )
 
     # images check
-    images_sub.add_parser("check", help="Check image and base image states")
+    images_check = images_sub.add_parser(
+        "check",
+        help="Query the registry for digest drift on enrolled images",
+    )
+    images_check.add_argument(
+        "--image",
+        default=None,
+        help="Scope check to a single image name (state file stem)",
+    )
+    images_check.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format: table (default) or json",
+    )
 
     # images status
     images_sub.add_parser("status", help="Show status of all images")

--- a/app/app.py
+++ b/app/app.py
@@ -7,6 +7,7 @@ Commands:
   images enrol          Enrol a new image in images.yaml
   images check          Check image and base image states
   images status         Show status of all images
+  images check-upstream Query Docker Hub for new upstream tags across enrolled images
   pipeline run          Run full pipeline (validate -> check -> build -> deploy -> test)
   pipeline build        Trigger a build via GitHub Actions
   pipeline deploy       Deploy via ArgoCD
@@ -1393,13 +1394,105 @@ def cmd_actions(args) -> int:
     }[args.actions_command](args)
 
 
+def cmd_images_check_upstream(args) -> int:
+    """Query Docker Hub for new upstream tags across enrolled images."""
+    DOCKER_HUB_TAGS_URL = (
+        "https://hub.docker.com/v2/repositories/{namespace}/{image}"
+        "/tags?page_size=100&ordering=last_updated"
+    )
+
+    def get_dockerhub_tags(namespace: str, image: str) -> List[str]:
+        url = DOCKER_HUB_TAGS_URL.format(namespace=namespace, image=image)
+        tags: List[str] = []
+        page = 0
+        try:
+            while url and page < 10:
+                req = urllib.request.Request(url)
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    data = json.loads(resp.read())
+                tags.extend(t["name"] for t in data.get("results", []))
+                url = data.get("next") or ""
+                page += 1
+        except Exception as exc:
+            logger.warning(f"Could not fetch tags for {namespace}/{image}: {exc}")
+        return tags
+
+    def is_stable_tag(tag: str) -> bool:
+        skip = {"latest", "edge", "nightly", "testing"}
+        if tag in skip:
+            return False
+        for suffix in ("-rc", "-alpha", "-beta", "-dev", "-test", ".rc", "-SNAPSHOT"):
+            if suffix in tag.lower():
+                return False
+        if tag.startswith("sha256:") or len(tag) == 64:
+            return False
+        return True
+
+    images_yaml = Path(args.images_yaml)
+    if not images_yaml.exists():
+        print(f"Error: images.yaml not found: {images_yaml}", file=sys.stderr)
+        return 1
+
+    with open(images_yaml) as f:
+        all_images = yaml.safe_load(f) or []
+
+    if not isinstance(all_images, list):
+        print("Error: images.yaml must be a list", file=sys.stderr)
+        return 1
+
+    if args.image:
+        images_to_check = [img for img in all_images if img.get("name") == args.image]
+        if not images_to_check:
+            print(f"Error: image '{args.image}' not found in images.yaml", file=sys.stderr)
+            return 1
+    else:
+        images_to_check = [img for img in all_images if img.get("enabled", True)]
+
+    findings: List[Dict] = []
+
+    for img in images_to_check:
+        name = img["image"]
+        namespace = img.get("namespace", "library")
+        current_tags: Set[str] = set(img.get("latest_stable_tags", []))
+
+        logger.info(f"Checking {name} (namespace={namespace})")
+        upstream_tags = get_dockerhub_tags(namespace, name)
+        stable_upstream = {t for t in upstream_tags if is_stable_tag(t)}
+
+        new_tags = stable_upstream - current_tags
+        surfaced = []
+        for t in new_tags:
+            base = t.split("-")[0].split(".")[0]
+            if not current_tags or any(
+                c.split("-")[0].split(".")[0] == base for c in current_tags
+            ):
+                surfaced.append(t)
+
+        if surfaced:
+            findings.append({"image": name, "new_tags": sorted(surfaced)})
+
+    has_new = len(findings) > 0
+
+    if args.format == "json":
+        print(json.dumps(findings, indent=2))
+    else:
+        if not findings:
+            print("No new upstream tags detected.")
+        else:
+            for entry in findings:
+                print(f"{entry['image']}: {', '.join(entry['new_tags'])}")
+
+    return 1 if has_new else 0
+
+
 def cmd_images(args) -> int:
     """Dispatch 'images' subcommands."""
     return {
-        "validate": cmd_validate,
-        "enrol":    cmd_enrol,
-        "check":    cmd_check,
-        "status":   cmd_status,
+        "validate":       cmd_validate,
+        "enrol":          cmd_enrol,
+        "check":          cmd_check,
+        "status":         cmd_status,
+        "check-upstream": cmd_images_check_upstream,
     }[args.images_command](args)
 
 
@@ -1552,6 +1645,23 @@ Commands:
 
     # images status
     images_sub.add_parser("status", help="Show status of all images")
+
+    # images check-upstream
+    images_check_upstream = images_sub.add_parser(
+        "check-upstream",
+        help="Query Docker Hub for new upstream tags across enrolled images",
+    )
+    images_check_upstream.add_argument(
+        "--image",
+        default=None,
+        help="Scope check to a single image name (as listed in images.yaml)",
+    )
+    images_check_upstream.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format: table (default) or json",
+    )
 
     # ---------------------------------------------------------------------------
     # pipeline — CI/CD orchestration

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -20,6 +20,7 @@ from app import (
     cmd_check,
     cmd_deploy,
     cmd_enrol,
+    cmd_images_check_upstream,
     cmd_status,
     cmd_test,
     cmd_validate,
@@ -676,6 +677,181 @@ class TestParser:
         args = parser.parse_args(["pipeline", "run"])
         assert args.command == "pipeline"
         assert args.pipeline_command == "run"
+
+
+# ---------------------------------------------------------------------------
+# cmd_images_check_upstream
+# ---------------------------------------------------------------------------
+
+
+def _make_dh_response(tags, next_url=None):
+    """Build a mock Docker Hub tags API response."""
+    body = json.dumps({"results": [{"name": t} for t in tags], "next": next_url}).encode()
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestCmdImagesCheckUpstream:
+
+    def _write_images_yaml(self, tmp_path, images):
+        p = tmp_path / "images.yaml"
+        p.write_text(yaml.dump(images))
+        return str(p)
+
+    def _args(self, images_yaml, image=None, fmt="table"):
+        return SimpleNamespace(images_yaml=images_yaml, image=image, format=fmt)
+
+    # --- no new tags ---
+
+    def test_no_new_tags_returns_0(self, tmp_path):
+        # Upstream returns exactly the enrolled tags — nothing surfaced.
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.28"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    def test_no_new_tags_table_output(self, tmp_path, capsys):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "alpine", "namespace": "library", "latest_stable_tags": ["3.19"], "enabled": True}
+        ])
+        resp = _make_dh_response(["3.19"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            cmd_images_check_upstream(self._args(images_yaml))
+        assert "No new upstream tags" in capsys.readouterr().out
+
+    # --- new tags found ---
+
+    def test_new_tag_returns_1(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 1
+
+    def test_new_tag_json_output(self, tmp_path, capsys):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            cmd_images_check_upstream(self._args(images_yaml, fmt="json"))
+        out = json.loads(capsys.readouterr().out)
+        assert out == [{"image": "nginx", "new_tags": ["1.28"]}]
+
+    def test_new_tag_table_output(self, tmp_path, capsys):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            cmd_images_check_upstream(self._args(images_yaml))
+        assert "nginx: 1.28" in capsys.readouterr().out
+
+    # --- stable-tag filtering ---
+
+    def test_skips_latest(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "latest"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    def test_skips_rc_tags(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        resp = _make_dh_response(["1.27", "1.28-rc1", "1.28-alpha"])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    def test_skips_sha_tags(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        sha = "a" * 64
+        resp = _make_dh_response(["1.27", sha])
+        with patch("urllib.request.urlopen", return_value=resp):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0
+
+    # --- --image scoping ---
+
+    def test_image_filter_scopes_check(self, tmp_path):
+        # --image scopes by the `name` field; only the matching image is queried.
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"name": "nginx", "image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True},
+            {"name": "alpine", "image": "alpine", "namespace": "library", "latest_stable_tags": ["3.19"], "enabled": True},
+        ])
+        # Mock only called once (for nginx); returns only enrolled tag → no new tags.
+        resp = _make_dh_response(["1.27"])
+        with patch("urllib.request.urlopen", return_value=resp) as mock_urlopen:
+            rc = cmd_images_check_upstream(self._args(images_yaml, image="nginx"))
+        mock_urlopen.assert_called_once()
+        assert rc == 0
+
+    def test_image_filter_unknown_name_returns_1(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        rc = cmd_images_check_upstream(self._args(images_yaml, image="nonexistent"))
+        assert rc == 1
+
+    # --- disabled images skipped ---
+
+    def test_disabled_images_skipped(self, tmp_path):
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": False}
+        ])
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        mock_urlopen.assert_not_called()
+        assert rc == 0
+
+    # --- missing images.yaml ---
+
+    def test_missing_images_yaml_returns_1(self, tmp_path):
+        rc = cmd_images_check_upstream(self._args(str(tmp_path / "missing.yaml")))
+        assert rc == 1
+
+    # --- network error is non-fatal ---
+
+    def test_network_error_is_non_fatal(self, tmp_path):
+        import urllib.error
+        images_yaml = self._write_images_yaml(tmp_path, [
+            {"image": "nginx", "namespace": "library", "latest_stable_tags": ["1.27"], "enabled": True}
+        ])
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("timeout")):
+            rc = cmd_images_check_upstream(self._args(images_yaml))
+        assert rc == 0  # no tags surfaced when network fails
+
+    # --- parser wiring ---
+
+    def test_parser_check_upstream_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args(["images", "check-upstream"])
+        assert args.command == "images"
+        assert args.images_command == "check-upstream"
+        assert args.format == "table"
+        assert args.image is None
+
+    def test_parser_check_upstream_with_flags(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["images", "check-upstream", "--format", "json", "--image", "nginx"]
+        )
+        assert args.format == "json"
+        assert args.image == "nginx"
 
 
 if __name__ == "__main__":

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from app import (
     ArgoCDProvider,
     GitHubActionsProvider,
+    _fetch_manifest_digest,
     build_parser,
     cmd_check,
     cmd_deploy,
@@ -52,6 +53,7 @@ def _args(**kwargs):
         rebuild_delay=None,
         auto_rebuild=False,
         image=None,
+        format="table",
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -266,43 +268,235 @@ class TestCmdEnrol:
 # ---------------------------------------------------------------------------
 
 
+DIGEST_A = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+DIGEST_B = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+class TestFetchManifestDigest:
+    """Unit tests for _fetch_manifest_digest (network isolated)."""
+
+    def _mock_urlopen(self, token_digest_pairs):
+        """Return a side-effect list: first call returns token JSON, second returns digest header."""
+        calls = iter(token_digest_pairs)
+
+        def _urlopen(req, timeout=10):
+            token_json, digest = next(calls)
+            resp = MagicMock()
+            resp.read.return_value = json.dumps({"token": token_json}).encode()
+            resp.headers = {"Docker-Content-Digest": digest} if digest else {}
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        return _urlopen
+
+    def test_dockerhub_returns_digest(self):
+        responses = [("tok", None), (None, DIGEST_A)]
+        with patch("urllib.request.urlopen", side_effect=self._mock_urlopen(responses)):
+            result = _fetch_manifest_digest("docker.io", "library/node", "22")
+        assert result == DIGEST_A
+
+    def test_ghcr_returns_digest(self):
+        responses = [("tok", None), (None, DIGEST_A)]
+        with patch("urllib.request.urlopen", side_effect=self._mock_urlopen(responses)):
+            result = _fetch_manifest_digest("ghcr.io", "myorg/myapp", "1.0.0")
+        assert result == DIGEST_A
+
+    def test_network_error_returns_none(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+            result = _fetch_manifest_digest("docker.io", "library/node", "22")
+        assert result is None
+
+    def test_missing_digest_header_returns_none(self):
+        responses = [("tok", None), (None, None)]
+        with patch("urllib.request.urlopen", side_effect=self._mock_urlopen(responses)):
+            result = _fetch_manifest_digest("docker.io", "library/node", "22")
+        assert result is None
+
+
 class TestCmdCheck:
-    def _make_state(self, tmp_path):
+    def _make_dirs(self, tmp_path):
         images_dir = tmp_path / "images"
         images_dir.mkdir(parents=True)
         base_dir = tmp_path / "base-images"
         base_dir.mkdir(parents=True)
         return tmp_path, images_dir, base_dir
 
-    def test_check_with_state_files(self, tmp_path):
-        state_dir, images_dir, base_dir = self._make_state(tmp_path)
+    def _base_image_state(self, name="node-22", registry="docker.io",
+                           repository="library/node", tag="22", digest=DIGEST_A):
+        return {
+            "name": name,
+            "registry": registry,
+            "repository": repository,
+            "tag": tag,
+            "currentDigest": digest,
+        }
 
-        (images_dir / "myapp.yaml").write_text(
-            yaml.dump(
-                {
-                    "name": "myapp",
-                    "currentDigest": "sha256:abc",
-                    "lastBuilt": "2025-01-01T00:00:00Z",
-                    "discoveryStatus": "pending",
-                }
-            )
-        )
-        (base_dir / "node-22.yaml").write_text(
-            yaml.dump(
-                {
-                    "name": "node-22",
-                    "currentDigest": "sha256:def",
-                    "lastUpdated": "2025-01-01T00:00:00Z",
-                }
-            )
-        )
+    def _app_image_state(self, name="myapp", registry="ghcr.io",
+                          repository="myorg/myapp", version="1.0.0", digest=DIGEST_A):
+        return {
+            "name": name,
+            "enrollment": {"registry": registry, "repository": repository},
+            "currentVersion": version,
+            "currentDigest": digest,
+        }
 
-        rc = cmd_check(_args(state_dir=str(state_dir)))
+    # ── clean match ─────────────────────────────────────────────────────────
+
+    def test_clean_base_image_returns_0(self, tmp_path):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state()))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+            rc = cmd_check(_args(state_dir=str(state_dir)))
         assert rc == 0
 
-    def test_check_empty_state_dir(self, tmp_path):
+    def test_clean_app_image_returns_0(self, tmp_path):
+        state_dir, images_dir, _ = self._make_dirs(tmp_path)
+        (images_dir / "myapp.yaml").write_text(yaml.dump(self._app_image_state()))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+            rc = cmd_check(_args(state_dir=str(state_dir)))
+        assert rc == 0
+
+    # ── drift detected ───────────────────────────────────────────────────────
+
+    def test_drift_base_image_returns_1(self, tmp_path):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state(digest=DIGEST_A)))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_B):
+            rc = cmd_check(_args(state_dir=str(state_dir)))
+        assert rc == 1
+
+    def test_drift_app_image_returns_1(self, tmp_path):
+        state_dir, images_dir, _ = self._make_dirs(tmp_path)
+        (images_dir / "myapp.yaml").write_text(yaml.dump(self._app_image_state(digest=DIGEST_A)))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_B):
+            rc = cmd_check(_args(state_dir=str(state_dir)))
+        assert rc == 1
+
+    def test_drift_table_output(self, tmp_path, capsys):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state(digest=DIGEST_A)))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_B):
+            cmd_check(_args(state_dir=str(state_dir)))
+        out = capsys.readouterr().out
+        assert "DRIFT" in out
+        assert "node-22" in out
+
+    def test_clean_table_output(self, tmp_path, capsys):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state()))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+            cmd_check(_args(state_dir=str(state_dir)))
+        out = capsys.readouterr().out
+        assert "ok" in out
+        assert "node-22" in out
+
+    # ── json output ──────────────────────────────────────────────────────────
+
+    def test_drift_json_output(self, tmp_path, capsys):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state(digest=DIGEST_A)))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_B):
+            cmd_check(_args(state_dir=str(state_dir), format="json"))
+        data = json.loads(capsys.readouterr().out)
+        assert len(data) == 1
+        assert data[0]["status"] == "drift"
+        assert data[0]["image"] == "node-22"
+
+    def test_clean_json_output(self, tmp_path, capsys):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state()))
+
+        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+            cmd_check(_args(state_dir=str(state_dir), format="json"))
+        data = json.loads(capsys.readouterr().out)
+        assert data[0]["status"] == "ok"
+
+    # ── network error non-fatal ──────────────────────────────────────────────
+
+    def test_registry_error_is_non_fatal(self, tmp_path):
+        """Network failure must not raise — returns 0 (no drift confirmed)."""
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state()))
+
+        with patch("app._fetch_manifest_digest", return_value=None):
+            rc = cmd_check(_args(state_dir=str(state_dir)))
+        assert rc == 0
+
+    def test_registry_error_shown_in_output(self, tmp_path, capsys):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state()))
+
+        with patch("app._fetch_manifest_digest", return_value=None):
+            cmd_check(_args(state_dir=str(state_dir)))
+        assert "error" in capsys.readouterr().out
+
+    # ── --image scoping ──────────────────────────────────────────────────────
+
+    def test_image_filter_scopes_to_named_image(self, tmp_path):
+        state_dir, _, base_dir = self._make_dirs(tmp_path)
+        (base_dir / "node-22.yaml").write_text(yaml.dump(self._base_image_state(name="node-22", digest=DIGEST_A)))
+        (base_dir / "alpine.yaml").write_text(yaml.dump(self._base_image_state(name="alpine", digest=DIGEST_A)))
+
+        call_args = []
+        def _mock_fetch(registry, repository, tag, token=None):
+            call_args.append(repository)
+            return DIGEST_A
+
+        with patch("app._fetch_manifest_digest", side_effect=_mock_fetch):
+            rc = cmd_check(_args(state_dir=str(state_dir), image="node-22"))
+
+        assert rc == 0
+        # Only one image was queried
+        assert len(call_args) == 1
+
+    def test_image_filter_not_found_returns_1(self, tmp_path):
+        state_dir, _, _ = self._make_dirs(tmp_path)
+        rc = cmd_check(_args(state_dir=str(state_dir), image="nonexistent"))
+        assert rc == 1
+
+    # ── skipped when no tag ──────────────────────────────────────────────────
+
+    def test_app_image_without_version_is_skipped(self, tmp_path):
+        state_dir, images_dir, _ = self._make_dirs(tmp_path)
+        (images_dir / "myapp.yaml").write_text(yaml.dump({
+            "name": "myapp",
+            "enrollment": {"registry": "ghcr.io", "repository": "myorg/myapp"},
+            "currentVersion": None,
+            "currentDigest": None,
+        }))
+
+        with patch("app._fetch_manifest_digest") as mock_fetch:
+            rc = cmd_check(_args(state_dir=str(state_dir)))
+        mock_fetch.assert_not_called()
+        assert rc == 0
+
+    # ── empty state dir ──────────────────────────────────────────────────────
+
+    def test_empty_state_dir_returns_0(self, tmp_path):
         rc = cmd_check(_args(state_dir=str(tmp_path)))
         assert rc == 0
+
+    # ── parser ───────────────────────────────────────────────────────────────
+
+    def test_parser_check_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args(["images", "check"])
+        assert args.image is None
+        assert args.format == "table"
+
+    def test_parser_check_with_flags(self):
+        parser = build_parser()
+        args = parser.parse_args(["images", "check", "--image", "node-22", "--format", "json"])
+        assert args.image == "node-22"
+        assert args.format == "json"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes `cascadeguard images check` to query the live registry for digest drift instead of reading local state files only. Closes [CAS-395](/CAS/issues/CAS-395).

> **Note:** This branch includes the `images check-upstream` subcommand from [CAS-375](/CAS/issues/CAS-375) as a foundation commit, since that branch has not yet been merged to main.

### Changes

- Adds `_fetch_manifest_digest()` (stdlib `urllib`, no new deps) supporting Docker Hub (anonymous token) and GHCR (`GHCR_TOKEN`/`GITHUB_TOKEN`)
- `cmd_check` now queries registry v2 API and compares live digest against `currentDigest` in state files
- Exit 1 on any drift, 0 when clean (network errors are non-fatal and reported as `error`)
- Adds `--image <name>` flag to scope to a single image
- Adds `--format json|table` flag
- App images without a recorded `currentVersion` are skipped gracefully

### Behaviour matrix

| Scenario | Output | Exit |
|---|---|---|
| Live digest matches recorded | `ok (sha256:…)` | 0 |
| Live digest differs | `DRIFT recorded=… live=…` | 1 |
| Registry unreachable | `error (registry unreachable)` | 0 |
| No version recorded | `skipped (no version/tag recorded yet)` | 0 |

## Test plan

- [x] 20 new unit tests; 302 total passing
- [x] Covers: clean match, drift, network error non-fatal, `--image` scoping, `--format json|table`, app images without version, parser defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)