### PR TITLE
fix(CAS-411): handle null Vulnerabilities in Trivy JSON output

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -994,7 +994,7 @@ def _parse_trivy_cves(trivy_path: Path) -> List[Dict]:
         data = json.load(f)
     findings = []
     for result in data.get("Results", []):
-        for vuln in result.get("Vulnerabilities", []):
+        for vuln in (result.get("Vulnerabilities") or []):
             findings.append({
                 "cve": vuln.get("VulnerabilityID", "UNKNOWN"),
                 "severity": vuln.get("Severity", "Unknown").capitalize(),

--- a/app/tests/test_scan.py
+++ b/app/tests/test_scan.py
@@ -106,6 +106,14 @@ class TestParseTrivy:
         assert findings[0]["severity"] == "Critical"
         assert findings[1]["cve"] == "CVE-2026-9999"
 
+    def test_parse_trivy_null_vulnerabilities(self, tmp_path):
+        # Trivy outputs "Vulnerabilities": null (not []) for clean images
+        trivy_file = tmp_path / "trivy.json"
+        trivy_file.write_text(json.dumps({
+            "Results": [{"Type": "alpine", "Vulnerabilities": None}]
+        }))
+        assert _parse_trivy_cves(trivy_file) == []
+
     def test_parse_trivy_missing_file(self, tmp_path):
         assert _parse_trivy_cves(tmp_path / "nope.json") == []
 


### PR DESCRIPTION
## Summary

- **Root cause**: `_parse_trivy_cves` crashes with `TypeError: 'NoneType' object is not iterable` when Trivy emits `"Vulnerabilities": null` for clean image layers (no CRITICAL/HIGH CVEs)
- **Fix**: Replace `result.get("Vulnerabilities", [])` with `(result.get("Vulnerabilities") or [])` — handles both `null` and missing key
- **Test added**: `test_parse_trivy_null_vulnerabilities` covers the exact failure case

## Root Cause Analysis

Trivy outputs `"Vulnerabilities": null` (not `[]`) when severity filtering (`CRITICAL,HIGH`) matches nothing. `dict.get(key, default)` only returns the default when the key is **absent** — a present `null` returns `None`. Iterating over `None` raises `TypeError`, crashing `cascadeguard vuln report` and failing the workflow step.

**Failure timeline:**
| Date | Cause |
|------|-------|
| Apr 5 | `cascadeguard scan-report` not yet merged to `main` at 06:00 UTC run time |
| Apr 6–8 | `TypeError` crash on any image with no critical/high CVEs (this bug) |
| Apr 9 | Action SHA fix (CAS-376) updated command name but not this underlying crash |

## Test plan

- [x] New regression test `test_parse_trivy_null_vulnerabilities` passes
- [x] All 270 existing tests pass (`270 passed in 2.35s`)
- [ ] CTO review
- [ ] Scheduled scan re-run to verify

Fixes: CAS-411

🤖 Generated with [Claude Code](https://claude.com/claude-code)