### PR TITLE
fix(ci): correct stale v4 annotation on actions/checkout SHA in enforce-actions-policy

### DIFF
--- a/.github/workflows/enforce-actions-policy.yaml
+++ b/.github/workflows/enforce-actions-policy.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Summary

- Dependabot PR #76 updated `actions/checkout` in `enforce-actions-policy.yaml` to SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) but left the comment annotation as `# v4`
- This is a one-line fix to correct the annotation to `# v6.0.2` for accuracy and auditability

## Test plan

- [ ] CI passes (enforce-actions-policy workflow runs clean)
- [ ] Verify annotation matches SHA in `.github/workflows/enforce-actions-policy.yaml`

Linked issue: [CAS-456](/CAS/issues/CAS-456)

🤖 Generated with [Claude Code](https://claude.com/claude-code)