### PR TITLE
fix(CAS-470): update acceptance test for PR#78 state layout change

### DIFF
--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -98,9 +98,10 @@ class TestGenerateStateCLI:
         images_dir = workspace['output_dir'] / "images"
         assert (images_dir / "backstage.yaml").exists(), "backstage state file not created"
 
-        # Verify base image state files were created for images.yaml entries without source
-        base_dir = workspace['output_dir'] / "base-images"
-        assert (base_dir / "postgres.yaml").exists(), "postgres state file not created"
+        # Since PR#78, all enrolled images (including registry-tracked ones without
+        # a dockerfile) go to images/. The base-images/ dir is now reserved exclusively
+        # for images discovered from Dockerfile FROM statements during check runs.
+        assert (images_dir / "postgres.yaml").exists(), "postgres state file not created"
 
         # Discovered base images from Dockerfile parsing are referenced by name
         # in the app image's baseImages field, not as separate state files
@@ -112,8 +113,8 @@ class TestGenerateStateCLI:
         assert "node-22-bookworm-slim" in content
         assert "CascadeGuard" in content
 
-        # Verify postgres (external, no source) state content
-        with open(base_dir / "postgres.yaml") as f:
+        # Verify postgres (external, no dockerfile) state content
+        with open(images_dir / "postgres.yaml") as f:
             data = yaml.safe_load(f)
         assert data['name'] == 'postgres'
 


### PR DESCRIPTION
## Root Cause

PR#78 (`feat(cli): Check generates state files and checks upstreams`) changed `generate_state_for_image` so **all enrolled images** — including registry-tracked ones without a `dockerfile` — now go to `images/`. Previously, images without a `source` were written to `base-images/`.

The comment in the updated code is explicit:
> All enrolled images go to images/ — base-images/ is only for upstream images discovered from Dockerfile FROM statements.

## What Failed

`TestGenerateStateCLI.test_cli_generates_state_files` was asserting that `postgres` (no source, no dockerfile) existed at `base-images/postgres.yaml`. After PR#78 it is at `images/postgres.yaml`.

## Fix

Updated `tests/acceptance/test_acceptance.py` to check `images/postgres.yaml` and read content from there. Added a comment explaining the new layout convention.

No behavior change — purely a test expectation update to match the intentional behavior introduced by PR#78.

Closes CAS-470

🤖 Generated with [Claude Code](https://claude.com/claude-code)