### PR TITLE
feat: quarantine-gated Dockerfile promotion in cg images check

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -178,8 +178,11 @@ class CascadeGuardTool:
             'firstDiscovered': now,
             'lastChecked': now,
             'currentDigest': None,
-            'lastUpdated': None,
+            'publishedAt': None,
+            'observedAt': None,
             'previousDigest': None,
+            'promotedDigest': None,
+            'promotedAt': None,
             'rebuildEligibleAt': {'default': None},
             'metadata': {},
             'updateHistory': [],
@@ -211,9 +214,14 @@ class CascadeGuardTool:
             f.write(f"lastChecked: {yaml.dump(state['lastChecked'], default_flow_style=True).strip()}\n\n")
             
             f.write("# Current state\n")
-            f.write(f"currentDigest: {self._yaml_value(state['currentDigest'])}\n")
-            f.write(f"lastUpdated: {self._yaml_value(state['lastUpdated'])}  # Will be set when digest first changes\n")
-            f.write(f"previousDigest: {self._yaml_value(state['previousDigest'])}\n\n")
+            f.write(f"currentDigest: {self._yaml_value(state.get('currentDigest'))}\n")
+            f.write(f"publishedAt: {self._yaml_value(state.get('publishedAt'))}  # when upstream built this digest\n")
+            f.write(f"observedAt: {self._yaml_value(state.get('observedAt'))}  # when we first saw this digest\n")
+            f.write(f"previousDigest: {self._yaml_value(state.get('previousDigest'))}\n\n")
+            
+            f.write("# Promotion tracking\n")
+            f.write(f"promotedDigest: {self._yaml_value(state.get('promotedDigest'))}  # last digest pinned in Dockerfiles\n")
+            f.write(f"promotedAt: {self._yaml_value(state.get('promotedAt'))}\n\n")
             
             f.write("# Rebuild eligibility\n")
             f.write(f"rebuildEligibleAt:\n")
@@ -232,7 +240,10 @@ class CascadeGuardTool:
             if state.get('updateHistory'):
                 f.write("updateHistory:\n")
                 for entry in state['updateHistory']:
-                    f.write(f"  - {yaml.dump(entry, default_flow_style=True).strip()}\n")
+                    f.write(f"  - digest: {entry.get('digest', 'null')}\n")
+                    f.write(f"    publishedAt: {self._yaml_value(entry.get('publishedAt'))}\n")
+                    f.write(f"    observedAt: {self._yaml_value(entry.get('observedAt'))}\n")
+                    f.write(f"    promotedAt: {self._yaml_value(entry.get('promotedAt'))}\n")
             else:
                 f.write("updateHistory: []\n")
             
@@ -856,6 +867,18 @@ def _fetch_manifest_digest(registry: str, repository: str, tag: str, token: Opti
     Docker-Content-Digest header value (e.g. 'sha256:abc…') or None when the
     registry is unreachable or the image/tag does not exist.
     """
+    info = _fetch_manifest_info(registry, repository, tag, token)
+    return info["digest"] if info else None
+
+
+def _fetch_manifest_info(
+    registry: str, repository: str, tag: str, token: Optional[str] = None
+) -> Optional[Dict[str, Optional[str]]]:
+    """Fetch digest and creation timestamp for a registry image.
+
+    Returns ``{"digest": "sha256:…", "publishedAt": "ISO-8601 or None"}``
+    or *None* when the registry is unreachable.
+    """
     ACCEPT = (
         "application/vnd.docker.distribution.manifest.v2+json,"
         "application/vnd.oci.image.manifest.v1+json,"
@@ -879,6 +902,33 @@ def _fetch_manifest_digest(registry: str, repository: str, tag: str, token: Opti
         with urllib.request.urlopen(req, timeout=10) as resp:
             return resp.headers.get("Docker-Content-Digest")
 
+    def _get_config_created(manifest_url: str, bearer: str, registry_base: str) -> Optional[str]:
+        """GET the manifest, then GET the config blob to extract 'created'."""
+        try:
+            req = urllib.request.Request(manifest_url)
+            req.add_header("Authorization", f"Bearer {bearer}")
+            req.add_header("Accept", ACCEPT)
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                manifest = json.loads(resp.read())
+
+            # OCI / Docker v2 manifest → config descriptor
+            config_desc = manifest.get("config")
+            if not config_desc:
+                return None
+            config_digest = config_desc.get("digest")
+            if not config_digest:
+                return None
+
+            blob_url = f"{registry_base}/v2/{repository}/blobs/{config_digest}"
+            req2 = urllib.request.Request(blob_url)
+            req2.add_header("Authorization", f"Bearer {bearer}")
+            with urllib.request.urlopen(req2, timeout=10) as resp2:
+                config_blob = json.loads(resp2.read())
+
+            return config_blob.get("created")
+        except Exception:
+            return None
+
     try:
         if registry in ("docker.io", "registry-1.docker.io", "index.docker.io", ""):
             auth_url = (
@@ -887,7 +937,8 @@ def _fetch_manifest_digest(registry: str, repository: str, tag: str, token: Opti
             )
             bearer = _get_token(auth_url)
             manifest_url = f"https://registry-1.docker.io/v2/{repository}/manifests/{tag}"
-            return _head_manifest(manifest_url, bearer)
+            registry_base = "https://registry-1.docker.io"
+            digest = _head_manifest(manifest_url, bearer)
 
         elif registry == "ghcr.io":
             ghcr_token = token or os.environ.get("GHCR_TOKEN") or os.environ.get("GITHUB_TOKEN")
@@ -898,17 +949,26 @@ def _fetch_manifest_digest(registry: str, repository: str, tag: str, token: Opti
             )
             bearer = _get_token(auth_url, creds)
             manifest_url = f"https://ghcr.io/v2/{repository}/manifests/{tag}"
-            return _head_manifest(manifest_url, bearer)
+            registry_base = "https://ghcr.io"
+            digest = _head_manifest(manifest_url, bearer)
 
         else:
-            # Generic registry v2 — attempt anonymous
             auth_url = (
                 f"https://{registry}/token"
                 f"?service={registry}&scope=repository:{repository}:pull"
             )
             bearer = _get_token(auth_url)
             manifest_url = f"https://{registry}/v2/{repository}/manifests/{tag}"
-            return _head_manifest(manifest_url, bearer)
+            registry_base = f"https://{registry}"
+            digest = _head_manifest(manifest_url, bearer)
+
+        if digest is None:
+            return None
+
+        # Fetch creation timestamp from config blob (best-effort)
+        published_at = _get_config_created(manifest_url, bearer, registry_base)
+
+        return {"digest": digest, "publishedAt": published_at}
 
     except Exception as exc:
         logger.warning(f"Could not query {registry}/{repository}:{tag}: {exc}")
@@ -1355,22 +1415,43 @@ def cmd_check(args) -> int:
                 results.append({"image": f"base:{name}", "status": "skipped", "reason": "no registry coordinates"})
                 continue
 
-            live_digest = _fetch_manifest_digest(registry, repository, tag)
-            if live_digest is None:
+            info = _fetch_manifest_info(registry, repository, tag)
+            if info is None:
                 results.append({"image": f"base:{name}", "status": "error", "reason": "registry unreachable"})
             elif recorded_digest is None:
-                results.append({"image": f"base:{name}", "status": "new", "live": live_digest})
-                # Record the digest — first observation, quarantine starts now
-                state["currentDigest"] = live_digest
-                state["lastUpdated"] = datetime.now(timezone.utc).isoformat()
+                # First observation
+                now_iso = datetime.now(timezone.utc).isoformat()
+                results.append({"image": f"base:{name}", "status": "new", "live": info["digest"]})
+                state["currentDigest"] = info["digest"]
+                state["publishedAt"] = info.get("publishedAt")
+                state["observedAt"] = now_iso
+                history = list(state.get("updateHistory") or [])
+                history.append({
+                    "digest": info["digest"],
+                    "publishedAt": info.get("publishedAt"),
+                    "observedAt": now_iso,
+                    "promotedAt": None,
+                })
+                state["updateHistory"] = history[-10:]
                 tool.write_base_image_state(state, state_file)
-            elif live_digest == recorded_digest:
+            elif info["digest"] == recorded_digest:
                 results.append({"image": f"base:{name}", "status": "ok", "digest": recorded_digest[:16]})
             else:
-                results.append({"image": f"base:{name}", "status": "drift", "recorded": recorded_digest[:16], "live": live_digest[:16]})
+                # Drift detected
+                now_iso = datetime.now(timezone.utc).isoformat()
+                results.append({"image": f"base:{name}", "status": "drift", "recorded": recorded_digest[:16], "live": info["digest"][:16]})
                 state["previousDigest"] = recorded_digest
-                state["currentDigest"] = live_digest
-                state["lastUpdated"] = datetime.now(timezone.utc).isoformat()
+                state["currentDigest"] = info["digest"]
+                state["publishedAt"] = info.get("publishedAt")
+                state["observedAt"] = now_iso
+                history = list(state.get("updateHistory") or [])
+                history.append({
+                    "digest": info["digest"],
+                    "publishedAt": info.get("publishedAt"),
+                    "observedAt": now_iso,
+                    "promotedAt": None,
+                })
+                state["updateHistory"] = history[-10:]
                 tool.write_base_image_state(state, state_file)
 
     # ── Phase 4: Check upstream tags (absorbed from check-upstream) ────────
@@ -1482,19 +1563,34 @@ def cmd_check(args) -> int:
                     continue
 
                 current_digest = bi_state.get("currentDigest")
-                last_updated_str = bi_state.get("lastUpdated")
-                if not current_digest or not last_updated_str:
+                promoted_digest = bi_state.get("promotedDigest")
+                if not current_digest:
                     continue
 
-                # Parse lastUpdated and check quarantine
+                # Already promoted this digest — nothing to do
+                if current_digest == promoted_digest:
+                    continue
+
+                # Determine quarantine start: prefer publishedAt (when
+                # upstream built it), fall back to observedAt (when we
+                # first saw it).
+                quarantine_start_str = (
+                    bi_state.get("publishedAt")
+                    or bi_state.get("observedAt")
+                    # Backwards compat with old state files
+                    or bi_state.get("lastUpdated")
+                )
+                if not quarantine_start_str:
+                    continue
+
                 try:
-                    last_updated = datetime.fromisoformat(last_updated_str)
-                    if last_updated.tzinfo is None:
-                        last_updated = last_updated.replace(tzinfo=timezone.utc)
+                    quarantine_start = datetime.fromisoformat(str(quarantine_start_str))
+                    if quarantine_start.tzinfo is None:
+                        quarantine_start = quarantine_start.replace(tzinfo=timezone.utc)
                 except (ValueError, TypeError):
                     continue
 
-                eligible_at = last_updated + timedelta(hours=q_hours)
+                eligible_at = quarantine_start + timedelta(hours=q_hours)
                 if now_dt < eligible_at:
                     remaining = eligible_at - now_dt
                     hours_left = remaining.total_seconds() / 3600
@@ -1524,6 +1620,18 @@ def cmd_check(args) -> int:
                         f"  ✓ {img_name}: promoted {bi_name} → {current_digest[:16]}… (quarantine: {q_hours}h)",
                         file=sys.stderr,
                     )
+
+                    # Update state: record promotion
+                    bi_state["promotedDigest"] = current_digest
+                    bi_state["promotedAt"] = now_dt.isoformat()
+                    # Update history entry
+                    history = list(bi_state.get("updateHistory") or [])
+                    for entry in history:
+                        if entry.get("digest") == current_digest and not entry.get("promotedAt"):
+                            entry["promotedAt"] = now_dt.isoformat()
+                    bi_state["updateHistory"] = history
+                    bi_state_file = base_images_dir / f"{bi_name}.yaml"
+                    tool.write_base_image_state(bi_state, bi_state_file)
 
     # ── Phase 6: Create PRs if requested (one per base image) ────────────
     pr_urls: List[str] = []

--- a/app/app.py
+++ b/app/app.py
@@ -30,7 +30,7 @@ import urllib.request
 import urllib.error
 from abc import ABC, abstractmethod
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Set
 import logging
 
@@ -956,6 +956,264 @@ def _is_stable_tag(tag: str) -> bool:
     return True
 
 
+# ── Quarantine ─────────────────────────────────────────────────────────────
+
+# Built-in default quarantine period (hours).  Overridden by
+# .cascadeguard.yaml  →  per-image in images.yaml.
+_DEFAULT_QUARANTINE_HOURS = 48
+
+
+def _parse_duration(value) -> Optional[int]:
+    """Parse a human duration string (e.g. '48h', '7d', '0') into hours.
+
+    Returns None when *value* is None or empty so callers can fall through
+    the config hierarchy.
+    """
+    if value is None:
+        return None
+    s = str(value).strip().lower()
+    if not s:
+        return None
+    if s in ("0", "none", "false", "disabled"):
+        return 0
+    m = re.match(r"^(\d+)\s*(h|d)$", s)
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        return n if unit == "h" else n * 24
+    # bare integer → treat as hours
+    if s.isdigit():
+        return int(s)
+    return None
+
+
+def _resolve_quarantine_hours(image: dict, config: dict) -> int:
+    """Resolve quarantine period for *image* using the config hierarchy.
+
+    Priority (highest wins):
+      1. images.yaml  per-image ``quarantine``
+      2. .cascadeguard.yaml  ``quarantine.period``
+      3. Built-in default (48 h)
+    """
+    # Per-image override
+    per_image = _parse_duration(image.get("quarantine"))
+    if per_image is not None:
+        return per_image
+
+    # Repo-level config
+    repo_level = _parse_duration(
+        config.get("quarantine", {}).get("period")
+        if isinstance(config.get("quarantine"), dict)
+        else config.get("quarantine")
+    )
+    if repo_level is not None:
+        return repo_level
+
+    return _DEFAULT_QUARANTINE_HOURS
+
+
+def _resolve_bool_setting(key: str, image: dict, config: dict, default: bool = True) -> bool:
+    """Resolve a boolean setting using the standard config hierarchy.
+
+    Priority (highest wins):
+      1. images.yaml  per-image value
+      2. .cascadeguard.yaml  value (nested under ``check:`` or top-level)
+      3. Built-in *default*
+    """
+    # Per-image override
+    per_image = image.get(key)
+    if per_image is not None:
+        return bool(per_image)
+
+    # Repo-level config — check under "check:" section first, then top-level
+    check_section = config.get("check", {})
+    if isinstance(check_section, dict) and key in check_section:
+        return bool(check_section[key])
+    if key in config:
+        return bool(config[key])
+
+    return default
+
+
+def _update_dockerfile_digest(dockerfile_path: Path, old_ref: str, new_digest: str) -> bool:
+    """Pin a Dockerfile FROM line to *new_digest*.
+
+    Transforms  ``FROM image:tag``  →  ``FROM image:tag@sha256:…``
+    and         ``FROM image:tag@sha256:old``  →  ``FROM image:tag@sha256:new``
+
+    Returns True if the file was modified.
+    """
+    if not dockerfile_path.exists():
+        return False
+
+    content = dockerfile_path.read_text()
+    lines = content.splitlines(keepends=True)
+    modified = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.upper().startswith("FROM "):
+            continue
+        # Extract the image reference (first token after FROM)
+        parts = stripped.split()
+        if len(parts) < 2:
+            continue
+        ref = parts[1]
+
+        # Match against old_ref (with or without existing digest)
+        base_ref = ref.split("@")[0]
+        old_base = old_ref.split("@")[0]
+        if base_ref != old_base:
+            continue
+
+        new_ref = f"{base_ref}@{new_digest}"
+        if ref == new_ref:
+            continue  # already pinned to this digest
+
+        lines[i] = line.replace(ref, new_ref, 1)
+        modified = True
+
+    if modified:
+        dockerfile_path.write_text("".join(lines))
+    return modified
+
+
+def _create_promotion_pr(
+    repo_root: Path,
+    promoted: List[Dict],
+    quarantine_hours: Dict[str, int],
+) -> List[str]:
+    """Open one PR per base image, dependabot-style.
+
+    Groups *promoted* entries by base image, creates a branch and PR for
+    each group.  This keeps PRs independent so they can be merged (or
+    reverted) individually and only the affected images rebuild.
+
+    Returns a list of PR URLs that were successfully created.
+    """
+    if shutil.which("gh") is None:
+        print("Warning: 'gh' CLI not found — skipping PR creation", file=sys.stderr)
+        return []
+
+    # Configure git once
+    _run_git(repo_root, ["config", "user.name", "cascadeguard[bot]"])
+    _run_git(repo_root, ["config", "user.email", "cascadeguard[bot]@users.noreply.github.com"])
+
+    # Group promoted entries by base image
+    by_base: Dict[str, List[Dict]] = {}
+    for p in promoted:
+        by_base.setdefault(p["base_image"], []).append(p)
+
+    scan_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    pr_urls: List[str] = []
+
+    for base_image, entries in by_base.items():
+        branch = f"cascadeguard/promote-{base_image}-{scan_date}"
+        new_digest = entries[0]["new_digest"]
+        q_hours = quarantine_hours.get(base_image, _DEFAULT_QUARANTINE_HOURS)
+        image_names = [e["image"] for e in entries]
+
+        # Create branch from main
+        _run_git(repo_root, ["checkout", "-B", branch, "main"])
+
+        # Re-apply the Dockerfile changes on this clean branch
+        for e in entries:
+            df_path = repo_root / e["dockerfile"]
+            _update_dockerfile_digest(
+                df_path,
+                e.get("full_ref", base_image),
+                new_digest,
+            )
+            _run_git(repo_root, ["add", e["dockerfile"]])
+
+        # Check there's something to commit
+        rc = subprocess.run(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=repo_root,
+            capture_output=True,
+        )
+        if rc.returncode == 0:
+            _run_git(repo_root, ["checkout", "main"])
+            continue
+
+        # Commit
+        if len(image_names) == 1:
+            commit_title = f"chore(deps): bump {base_image} in {image_names[0]}"
+        else:
+            commit_title = f"chore(deps): bump {base_image} in {len(image_names)} image(s)"
+
+        commit_body_lines = [
+            f"Upstream base image `{base_image}` passed {q_hours}h quarantine.",
+            f"Pinning Dockerfile(s) to digest `{new_digest[:24]}…`\n",
+        ]
+        for e in entries:
+            commit_body_lines.append(f"  • {e['dockerfile']}")
+        commit_body_lines.append(f"\nCo-Authored-By: Paperclip <noreply@paperclip.ing>")
+        commit_msg = f"{commit_title}\n\n" + "\n".join(commit_body_lines)
+
+        _run_git(repo_root, ["commit", "-m", commit_msg])
+        _run_git(repo_root, ["push", "-u", "origin", branch, "--force"])
+
+        # Build PR body
+        pr_body_lines = [
+            f"## Upstream Promotion — `{base_image}`\n",
+            f"Bumps the `{base_image}` base image to digest "
+            f"`{new_digest[:24]}…`\n",
+            "### Quarantine\n",
+            f"| Rule | Value |",
+            f"|------|-------|",
+            f"| Quarantine period | **{q_hours}h** |",
+            f"| Drift detected | state file `lastUpdated` |",
+            f"| Eligible at | `lastUpdated + {q_hours}h` ✓ |",
+            "",
+            "### Affected images\n",
+            "| Image | Dockerfile |",
+            "|-------|-----------|",
+        ]
+        for e in entries:
+            pr_body_lines.append(f"| {e['image']} | `{e['dockerfile']}` |")
+        pr_body_lines.append("")
+        pr_body_lines.append(
+            "> Merging this PR will trigger the build pipeline for the "
+            "affected image(s) only."
+        )
+        pr_body_lines.append(
+            "> Created automatically by `cascadeguard images check "
+            "--promote --create-pr`."
+        )
+        pr_body = "\n".join(pr_body_lines)
+
+        result = subprocess.run(
+            [
+                "gh", "pr", "create",
+                "--title", commit_title,
+                "--body", pr_body,
+                "--base", "main",
+                "--head", branch,
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(
+                f"  Warning: PR for {base_image} failed: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+        else:
+            pr_url = result.stdout.strip()
+            pr_urls.append(pr_url)
+            print(f"  PR created for {base_image}: {pr_url}", file=sys.stderr)
+
+        _run_git(repo_root, ["checkout", "main"])
+
+    return pr_urls
+
+
+def _run_git(cwd: Path, args: List[str]):
+    """Run a git command, raising on failure."""
+    subprocess.run(["git"] + args, cwd=cwd, check=True, capture_output=True)
+
+
 def cmd_check(args) -> int:
     """Unified check: generate state, discover base images, query registries."""
     from generate_state import (
@@ -986,6 +1244,14 @@ def cmd_check(args) -> int:
 
     image_filter: Optional[str] = getattr(args, "image", None)
     fmt: str = getattr(args, "format", "table")
+
+    # Resolve promote/create-pr: CLI flag (explicit) > config > default (true)
+    promote_flag = getattr(args, "promote", None)
+    create_pr_flag = getattr(args, "create_pr", None)
+    # These are resolved per-image for promote, but we need a repo-level
+    # default for the overall flow.  Per-image override happens in Phase 5.
+    do_promote = promote_flag if promote_flag is not None else _resolve_bool_setting("promote", {}, config, default=True)
+    do_create_pr = create_pr_flag if create_pr_flag is not None else _resolve_bool_setting("createPr", {}, config, default=True)
 
     # ── Phase 1: Generate image state + discover base images ───────────────
     all_base_image_refs: Dict[str, str] = {}  # normalized_name -> full image ref
@@ -1094,7 +1360,7 @@ def cmd_check(args) -> int:
                 results.append({"image": f"base:{name}", "status": "error", "reason": "registry unreachable"})
             elif recorded_digest is None:
                 results.append({"image": f"base:{name}", "status": "new", "live": live_digest})
-                # Record the digest
+                # Record the digest — first observation, quarantine starts now
                 state["currentDigest"] = live_digest
                 state["lastUpdated"] = datetime.now(timezone.utc).isoformat()
                 tool.write_base_image_state(state, state_file)
@@ -1163,6 +1429,106 @@ def cmd_check(args) -> int:
                     print(f"  ? {img}: {r['reason']}")
                 elif status == "skipped":
                     print(f"  - {img}: skipped ({r['reason']})")
+
+    # ── Phase 5: Promote images past quarantine ────────────────────────────
+    promoted: List[Dict] = []
+    quarantine_hours_map: Dict[str, int] = {}
+
+    if do_promote:
+        now_dt = datetime.now(timezone.utc)
+
+        # Build a map: base_image_name -> {digest, lastUpdated} from state files
+        base_image_states: Dict[str, Dict] = {}
+        if base_images_dir.exists():
+            for state_file in sorted(base_images_dir.glob("*.yaml")):
+                with open(state_file) as f:
+                    st = yaml.safe_load(f) or {}
+                bi_name = st.get("name", state_file.stem)
+                base_image_states[bi_name] = st
+
+        # For each enrolled image, check if its base images have passed quarantine
+        for image in resolved_images:
+            img_name = image.get("name")
+            if not img_name or not image.get("enabled", True):
+                continue
+            if image_filter and img_name != image_filter:
+                continue
+
+            # Per-image promote override (images.yaml `promote: false`)
+            if not _resolve_bool_setting("promote", image, config, default=True):
+                continue
+
+            dockerfile_rel = image.get("dockerfile") or image.get("source", {}).get("dockerfile")
+            if not dockerfile_rel:
+                continue
+
+            dockerfile_path = repo_root / dockerfile_rel
+            if not dockerfile_path.exists():
+                continue
+
+            q_hours = _resolve_quarantine_hours(image, config)
+
+            # Check each base image this image depends on
+            img_state_file = images_dir / f"{img_name}.yaml"
+            if not img_state_file.exists():
+                continue
+            with open(img_state_file) as f:
+                img_state = yaml.safe_load(f) or {}
+            dep_base_images = img_state.get("baseImages", [])
+
+            for bi_name in dep_base_images:
+                bi_state = base_image_states.get(bi_name)
+                if not bi_state:
+                    continue
+
+                current_digest = bi_state.get("currentDigest")
+                last_updated_str = bi_state.get("lastUpdated")
+                if not current_digest or not last_updated_str:
+                    continue
+
+                # Parse lastUpdated and check quarantine
+                try:
+                    last_updated = datetime.fromisoformat(last_updated_str)
+                    if last_updated.tzinfo is None:
+                        last_updated = last_updated.replace(tzinfo=timezone.utc)
+                except (ValueError, TypeError):
+                    continue
+
+                eligible_at = last_updated + timedelta(hours=q_hours)
+                if now_dt < eligible_at:
+                    remaining = eligible_at - now_dt
+                    hours_left = remaining.total_seconds() / 3600
+                    print(
+                        f"  ⏳ {img_name}: {bi_name} in quarantine ({hours_left:.0f}h remaining)",
+                        file=sys.stderr,
+                    )
+                    continue
+
+                # Quarantine passed — update the Dockerfile
+                full_ref = all_base_image_refs.get(bi_name, bi_state.get("fullImage", ""))
+                if not full_ref:
+                    continue
+
+                modified = _update_dockerfile_digest(dockerfile_path, full_ref, current_digest)
+                if modified:
+                    quarantine_hours_map[bi_name] = q_hours
+                    promoted.append({
+                        "image": img_name,
+                        "base_image": bi_name,
+                        "dockerfile": dockerfile_rel,
+                        "new_digest": current_digest,
+                        "quarantine_hours": q_hours,
+                        "full_ref": full_ref,
+                    })
+                    print(
+                        f"  ✓ {img_name}: promoted {bi_name} → {current_digest[:16]}… (quarantine: {q_hours}h)",
+                        file=sys.stderr,
+                    )
+
+    # ── Phase 6: Create PRs if requested (one per base image) ────────────
+    pr_urls: List[str] = []
+    if do_create_pr and promoted:
+        pr_urls = _create_promotion_pr(repo_root, promoted, quarantine_hours_map)
 
     return 1 if (has_drift or has_new_tags) else 0
 
@@ -1977,6 +2343,18 @@ Commands:
         choices=["json", "table"],
         default="table",
         help="Output format: table (default) or json",
+    )
+    images_check.add_argument(
+        "--promote",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Update Dockerfiles for base images that have passed quarantine (default: true, use --no-promote to disable)",
+    )
+    images_check.add_argument(
+        "--create-pr",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Open a PR with promoted Dockerfile changes (default: true, use --no-create-pr to disable)",
     )
 
     # images status

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -53,6 +53,8 @@ def _args(**kwargs):
         auto_rebuild=False,
         image=None,
         format="table",
+        promote=False,
+        create_pr=False,
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -339,7 +341,7 @@ class TestCmdCheck:
             [{"name": "myapp", "dockerfile": "images/myapp/Dockerfile", "image": "myapp", "tag": "latest", "registry": "ghcr.io"}],
             {"images/myapp/Dockerfile": "FROM node:22-slim\nRUN echo hello\n"})
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_A, "publishedAt": None}):
             rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         assert rc == 0
         # Should have created base-images/node-22-slim.yaml
@@ -355,7 +357,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22", digest=DIGEST_A)
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_A, "publishedAt": None}):
             rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         assert rc == 0
 
@@ -367,7 +369,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22", digest=DIGEST_A)
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_B):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_B, "publishedAt": None}):
             rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         assert rc == 1
 
@@ -377,7 +379,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22", digest=DIGEST_A)
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_B):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_B, "publishedAt": None}):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         out = capsys.readouterr().out
         assert "DRIFT" in out
@@ -388,7 +390,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22", digest=DIGEST_A)
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_A, "publishedAt": None}):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         out = capsys.readouterr().out
         assert "node-22" in out
@@ -401,7 +403,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22", digest=DIGEST_A)
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_B):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_B, "publishedAt": None}):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, format="json"))
         data = json.loads(capsys.readouterr().out)
         assert any(d["status"] == "drift" for d in data)
@@ -412,7 +414,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22", digest=DIGEST_A)
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_A, "publishedAt": None}):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, format="json"))
         data = json.loads(capsys.readouterr().out)
         assert data[0]["status"] == "ok"
@@ -425,7 +427,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22")
 
-        with patch("app._fetch_manifest_digest", return_value=None):
+        with patch("app._fetch_manifest_info", return_value=None):
             rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         assert rc == 0
 
@@ -435,7 +437,7 @@ class TestCmdCheck:
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
         self._pre_seed_base_image(state_dir, "node-22")
 
-        with patch("app._fetch_manifest_digest", return_value=None):
+        with patch("app._fetch_manifest_info", return_value=None):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         out = capsys.readouterr().out
         assert "error" in out or "unreachable" in out
@@ -451,7 +453,7 @@ class TestCmdCheck:
             "images/other/Dockerfile": "FROM alpine:3.20\nRUN echo hello\n",
         })
 
-        with patch("app._fetch_manifest_digest", return_value=DIGEST_A):
+        with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_A, "publishedAt": None}):
             rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, image="myapp"))
         assert rc == 0
         # Only myapp's base image should be discovered, not other's
@@ -463,7 +465,7 @@ class TestCmdCheck:
         images_yaml, state_dir = self._setup_repo(tmp_path,
             [{"name": "memcached", "enabled": False}])
 
-        with patch("app._fetch_manifest_digest") as mock_fetch:
+        with patch("app._fetch_manifest_info") as mock_fetch:
             rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
         mock_fetch.assert_not_called()
         assert rc == 0

--- a/app/tests/test_check_promotion.py
+++ b/app/tests/test_check_promotion.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""Acceptance tests for the check → quarantine → promote → PR pipeline.
+
+These tests exercise the full cmd_check flow end-to-end with mocked
+registries and git operations.  Each test sets up a realistic repo
+structure (images.yaml, Dockerfiles, state files, config) and verifies
+the correct outcome across the quarantine/promotion matrix.
+"""
+
+import json
+import os
+import sys
+import pytest
+import yaml
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, call
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app import cmd_check, _DEFAULT_QUARANTINE_HOURS
+
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+DIGEST_OLD = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+DIGEST_NEW = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+DIGEST_NEW2 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _args(**kwargs):
+    """Build a SimpleNamespace with sensible defaults for cmd_check."""
+    defaults = dict(
+        images_yaml="images.yaml",
+        state_dir=".cascadeguard",
+        image=None,
+        format="table",
+        promote=None,       # None = resolve from config (default: true)
+        create_pr=None,     # None = resolve from config (default: true)
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _mock_info(digest, published_at=None):
+    """Return a _fetch_manifest_info-shaped dict."""
+    return {"digest": digest, "publishedAt": published_at}
+
+
+def _setup_repo(tmp_path, images, dockerfiles=None, config=None):
+    """Create a minimal repo with images.yaml, optional Dockerfiles and config."""
+    images_yaml = tmp_path / "images.yaml"
+    images_yaml.write_text(yaml.dump(images))
+
+    state_dir = tmp_path / ".cascadeguard"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    if config:
+        cfg_file = tmp_path / ".cascadeguard.yaml"
+        cfg_file.write_text(yaml.dump(config))
+
+    if dockerfiles:
+        for path, content in dockerfiles.items():
+            full = tmp_path / path
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_text(content)
+
+    return str(images_yaml), str(state_dir)
+
+
+def _seed_base_image_state(state_dir, name, digest=DIGEST_OLD,
+                            published_at=None, observed_at=None,
+                            promoted_digest=None, promoted_at=None,
+                            registry="docker.io",
+                            repository="library/node", tag="22"):
+    """Pre-seed a base-images state file simulating a previous check run."""
+    base_dir = Path(state_dir) / "base-images"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    state = {
+        "name": name,
+        "fullImage": f"{repository.split('/')[-1]}:{tag}",
+        "registry": registry,
+        "repository": repository,
+        "tag": tag,
+        "currentDigest": digest,
+        "publishedAt": published_at,
+        "observedAt": observed_at,
+        "previousDigest": None,
+        "promotedDigest": promoted_digest,
+        "promotedAt": promoted_at,
+        "lastChecked": "2025-01-01T00:00:00+00:00",
+        "allowTags": f"^{tag}$",
+        "imageSelectionStrategy": "Lexical",
+        "repoURL": f"{registry}/{repository}",
+        "firstDiscovered": "2025-01-01T00:00:00+00:00",
+        "rebuildEligibleAt": {"default": None},
+        "metadata": {},
+        "updateHistory": [],
+        "lastDiscovery": None,
+    }
+    (base_dir / f"{name}.yaml").write_text(
+        yaml.dump(state, default_flow_style=False)
+    )
+
+
+def _seed_image_state(state_dir, name, base_images, dockerfile=""):
+    """Pre-seed an images state file."""
+    images_dir = Path(state_dir) / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    state = {
+        "name": name,
+        "enrolledAt": "2025-01-01T00:00:00+00:00",
+        "lastChecked": "2025-01-01T00:00:00+00:00",
+        "registry": "ghcr.io",
+        "image": name,
+        "tag": "latest",
+        "dockerfile": dockerfile,
+        "baseImages": sorted(base_images),
+        "currentDigest": None,
+    }
+    (images_dir / f"{name}.yaml").write_text(
+        yaml.dump(state, default_flow_style=False)
+    )
+
+
+def _read_dockerfile(tmp_path, rel_path):
+    return (tmp_path / rel_path).read_text()
+
+
+# ── Acceptance Tests ───────────────────────────────────────────────────────
+
+# Standard image config used by most tests
+_MYAPP = {
+    "name": "myapp",
+    "dockerfile": "images/myapp/Dockerfile",
+    "image": "myapp", "tag": "latest",
+    "registry": "ghcr.io",
+}
+_MYAPP_DF = {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"}
+
+
+class TestDriftWithQuarantineNotElapsed:
+    """Upstream published 1h ago, quarantine is 48h → no promotion."""
+
+    def test_dockerfile_unchanged(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=one_hour_ago,
+                                observed_at=one_hour_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, one_hour_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert "@sha256:" not in content
+
+    def test_stderr_shows_quarantine_remaining(self, tmp_path, capsys):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=one_hour_ago,
+                                observed_at=one_hour_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, one_hour_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        err = capsys.readouterr().err
+        assert "quarantine" in err.lower()
+        assert "remaining" in err.lower()
+
+
+class TestDriftWithQuarantineElapsed:
+    """Upstream published 72h ago, quarantine is 48h → Dockerfile pinned."""
+
+    def test_dockerfile_pinned_to_new_digest(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert f"FROM node:22@{DIGEST_NEW}" in content
+
+    def test_stderr_shows_promotion(self, tmp_path, capsys):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        err = capsys.readouterr().err
+        assert "promoted" in err.lower()
+
+    def test_state_records_promotion(self, tmp_path):
+        """After promotion, promotedDigest should match currentDigest."""
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        bi_state = yaml.safe_load((Path(state_dir) / "base-images" / "node-22.yaml").read_text())
+        assert bi_state["promotedDigest"] == DIGEST_NEW
+        assert bi_state["promotedAt"] is not None
+
+    def test_already_promoted_digest_skipped(self, tmp_path):
+        """If promotedDigest == currentDigest, no Dockerfile change."""
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago,
+                                promoted_digest=DIGEST_NEW,
+                                promoted_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert "@sha256:" not in content
+
+
+class TestQuarantineUsesPublishedAt:
+    """Quarantine evaluates against publishedAt, not observedAt."""
+
+    def test_published_long_ago_observed_recently(self, tmp_path):
+        """Published 72h ago but we only saw it 1h ago → should promote."""
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        published = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        observed = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=published,
+                                observed_at=observed)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, published)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert f"FROM node:22@{DIGEST_NEW}" in content
+
+
+class TestQuarantineDisabled:
+    """quarantine: disabled → immediate promotion."""
+
+    def test_immediate_promotion(self, tmp_path):
+        myapp = dict(_MYAPP, quarantine="disabled")
+        images_yaml, state_dir = _setup_repo(tmp_path, [myapp], _MYAPP_DF)
+        just_now = datetime.now(timezone.utc).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=just_now,
+                                observed_at=just_now)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, just_now)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert f"FROM node:22@{DIGEST_NEW}" in content
+
+    def test_zero_quarantine(self, tmp_path):
+        myapp = dict(_MYAPP, quarantine="0")
+        images_yaml, state_dir = _setup_repo(tmp_path, [myapp], _MYAPP_DF)
+        just_now = datetime.now(timezone.utc).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=just_now,
+                                observed_at=just_now)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, just_now)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert f"FROM node:22@{DIGEST_NEW}" in content
+
+
+class TestNoDrift:
+    """No drift, digest already promoted → Dockerfile untouched."""
+
+    def test_dockerfile_unchanged(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_OLD,
+                                published_at=long_ago,
+                                observed_at=long_ago,
+                                promoted_digest=DIGEST_OLD,
+                                promoted_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_OLD, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        assert rc == 0
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert "@sha256:" not in content
+
+
+class TestPerImagePromoteFalse:
+    def test_dockerfile_unchanged(self, tmp_path):
+        myapp = dict(_MYAPP, promote=False)
+        images_yaml, state_dir = _setup_repo(tmp_path, [myapp], _MYAPP_DF)
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert "@sha256:" not in content
+
+
+class TestRepoLevelPromoteFalse:
+    def test_dockerfile_unchanged(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF,
+            config={"check": {"promote": False}})
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert "@sha256:" not in content
+
+
+class TestNoPromoteFlag:
+    def test_overrides_config(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir,
+                                promote=False, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert "@sha256:" not in content
+
+
+class TestCustomQuarantinePeriod:
+    def test_short_quarantine_promotes_early(self, tmp_path):
+        myapp = dict(_MYAPP, quarantine="2h")
+        images_yaml, state_dir = _setup_repo(tmp_path, [myapp], _MYAPP_DF)
+        three_hours_ago = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=three_hours_ago,
+                                observed_at=three_hours_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, three_hours_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert f"FROM node:22@{DIGEST_NEW}" in content
+
+    def test_long_quarantine_blocks(self, tmp_path):
+        myapp = dict(_MYAPP, quarantine="7d")
+        images_yaml, state_dir = _setup_repo(tmp_path, [myapp], _MYAPP_DF)
+        three_days_ago = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=three_days_ago,
+                                observed_at=three_days_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, three_days_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert "@sha256:" not in content
+
+
+class TestRepoLevelQuarantine:
+    def test_repo_config_overrides_default(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF,
+            config={"quarantine": {"period": "1h"}})
+        two_hours_ago = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=two_hours_ago,
+                                observed_at=two_hours_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, two_hours_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert f"FROM node:22@{DIGEST_NEW}" in content
+
+
+class TestUpdateHistory:
+    """Drift detection populates updateHistory with both timestamps."""
+
+    def test_history_entry_on_new_drift(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF)
+        old_time = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_OLD,
+                                published_at=old_time,
+                                observed_at=old_time,
+                                promoted_digest=DIGEST_OLD,
+                                promoted_at=old_time)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        new_published = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, new_published)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+
+        bi_state = yaml.safe_load((Path(state_dir) / "base-images" / "node-22.yaml").read_text())
+        assert bi_state["currentDigest"] == DIGEST_NEW
+        assert bi_state["previousDigest"] == DIGEST_OLD
+        history = bi_state.get("updateHistory", [])
+        assert len(history) >= 1
+        latest = history[-1]
+        assert latest["digest"] == DIGEST_NEW
+        assert latest["publishedAt"] is not None
+        assert latest["observedAt"] is not None
+        assert latest["promotedAt"] is None  # still in quarantine
+
+
+class TestNoCreatePrConfig:
+    """check.createPr: false → promote but no PR."""
+
+    def test_promotes_without_pr(self, tmp_path):
+        images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF,
+            config={"check": {"createPr": False}})
+        long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        _seed_base_image_state(state_dir, "node-22",
+                                digest=DIGEST_NEW,
+                                published_at=long_ago,
+                                observed_at=long_ago)
+        _seed_image_state(state_dir, "myapp", ["node-22"],
+                          dockerfile="images/myapp/Dockerfile")
+
+        with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
+            with patch("app._get_dockerhub_tags", return_value=[]):
+                with patch("subprocess.run") as mock_run:
+                    cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
+
+        content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
+        assert f"FROM node:22@{DIGEST_NEW}" in content
+
+        for c in mock_run.call_args_list:
+            args = c[0][0] if c[0] else []
+            assert "gh" not in args

--- a/app/tests/test_quarantine.py
+++ b/app/tests/test_quarantine.py
@@ -1,0 +1,251 @@
+"""Tests for quarantine resolution, Dockerfile digest pinning, and promotion flow."""
+
+import pytest
+import textwrap
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from app import (
+    _parse_duration,
+    _resolve_quarantine_hours,
+    _update_dockerfile_digest,
+    _DEFAULT_QUARANTINE_HOURS,
+)
+
+
+# ── _parse_duration ────────────────────────────────────────────────────────
+
+
+class TestParseDuration:
+    def test_none_returns_none(self):
+        assert _parse_duration(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_duration("") is None
+        assert _parse_duration("  ") is None
+
+    def test_hours(self):
+        assert _parse_duration("48h") == 48
+        assert _parse_duration("0h") == 0
+        assert _parse_duration("1h") == 1
+
+    def test_days(self):
+        assert _parse_duration("7d") == 168
+        assert _parse_duration("1d") == 24
+        assert _parse_duration("0d") == 0
+
+    def test_bare_integer_treated_as_hours(self):
+        assert _parse_duration("24") == 24
+        assert _parse_duration("0") == 0
+
+    def test_disabled_values(self):
+        assert _parse_duration("none") == 0
+        assert _parse_duration("false") == 0
+        assert _parse_duration("disabled") == 0
+
+    def test_case_insensitive(self):
+        assert _parse_duration("48H") == 48
+        assert _parse_duration("7D") == 168
+        assert _parse_duration("None") == 0
+        assert _parse_duration("DISABLED") == 0
+
+    def test_invalid_returns_none(self):
+        assert _parse_duration("abc") is None
+        assert _parse_duration("48x") is None
+
+
+# ── _resolve_quarantine_hours ──────────────────────────────────────────────
+
+
+class TestResolveQuarantineHours:
+    def test_default_when_no_config(self):
+        assert _resolve_quarantine_hours({}, {}) == _DEFAULT_QUARANTINE_HOURS
+
+    def test_repo_level_override(self):
+        config = {"quarantine": {"period": "24h"}}
+        assert _resolve_quarantine_hours({}, config) == 24
+
+    def test_repo_level_shorthand(self):
+        """quarantine: 72h  (not nested under .period)"""
+        config = {"quarantine": "72h"}
+        assert _resolve_quarantine_hours({}, config) == 72
+
+    def test_per_image_override(self):
+        image = {"quarantine": "12h"}
+        config = {"quarantine": {"period": "24h"}}
+        assert _resolve_quarantine_hours(image, config) == 12
+
+    def test_per_image_zero_disables(self):
+        image = {"quarantine": "0"}
+        assert _resolve_quarantine_hours(image, {}) == 0
+
+    def test_per_image_disabled(self):
+        image = {"quarantine": "disabled"}
+        assert _resolve_quarantine_hours(image, {}) == 0
+
+    def test_hierarchy_fallthrough(self):
+        """Per-image None → repo-level None → built-in default."""
+        image = {"quarantine": None}
+        config = {"quarantine": {"period": None}}
+        assert _resolve_quarantine_hours(image, config) == _DEFAULT_QUARANTINE_HOURS
+
+
+# ── _update_dockerfile_digest ──────────────────────────────────────────────
+
+
+class TestUpdateDockerfileDigest:
+    def test_pins_tag_only_from(self, tmp_path):
+        df = tmp_path / "Dockerfile"
+        df.write_text("FROM nginx:stable-alpine-slim AS build\nRUN echo hello\n")
+
+        modified = _update_dockerfile_digest(
+            df, "nginx:stable-alpine-slim", "sha256:abc123"
+        )
+        assert modified is True
+        content = df.read_text()
+        assert "FROM nginx:stable-alpine-slim@sha256:abc123 AS build" in content
+
+    def test_updates_existing_digest(self, tmp_path):
+        df = tmp_path / "Dockerfile"
+        df.write_text("FROM nginx:stable-alpine-slim@sha256:old123 AS build\n")
+
+        modified = _update_dockerfile_digest(
+            df, "nginx:stable-alpine-slim@sha256:old123", "sha256:new456"
+        )
+        assert modified is True
+        content = df.read_text()
+        assert "FROM nginx:stable-alpine-slim@sha256:new456 AS build" in content
+        assert "old123" not in content
+
+    def test_no_change_when_already_pinned(self, tmp_path):
+        df = tmp_path / "Dockerfile"
+        df.write_text("FROM nginx:stable-alpine-slim@sha256:abc123 AS build\n")
+
+        modified = _update_dockerfile_digest(
+            df, "nginx:stable-alpine-slim", "sha256:abc123"
+        )
+        assert modified is False
+
+    def test_no_match_returns_false(self, tmp_path):
+        df = tmp_path / "Dockerfile"
+        df.write_text("FROM python:3.12-slim AS build\n")
+
+        modified = _update_dockerfile_digest(
+            df, "nginx:stable-alpine-slim", "sha256:abc123"
+        )
+        assert modified is False
+        # File unchanged
+        assert "python:3.12-slim" in df.read_text()
+
+    def test_missing_file_returns_false(self, tmp_path):
+        df = tmp_path / "nonexistent" / "Dockerfile"
+        assert _update_dockerfile_digest(df, "nginx:tag", "sha256:abc") is False
+
+    def test_multistage_only_matches_correct_from(self, tmp_path):
+        df = tmp_path / "Dockerfile"
+        df.write_text(textwrap.dedent("""\
+            FROM golang:1.22 AS builder
+            RUN go build -o app .
+
+            FROM alpine:3.20 AS runtime
+            COPY --from=builder /app /app
+        """))
+
+        modified = _update_dockerfile_digest(
+            df, "alpine:3.20", "sha256:alpine_digest"
+        )
+        assert modified is True
+        content = df.read_text()
+        assert "FROM golang:1.22 AS builder" in content  # unchanged
+        assert "FROM alpine:3.20@sha256:alpine_digest AS runtime" in content
+
+    def test_preserves_comments_and_whitespace(self, tmp_path):
+        df = tmp_path / "Dockerfile"
+        original = textwrap.dedent("""\
+            # CascadeGuard Hardened Image
+            # https://github.com/cascadeguard
+
+            FROM nginx:stable-alpine-slim AS build
+
+            RUN echo hello
+        """)
+        df.write_text(original)
+
+        _update_dockerfile_digest(df, "nginx:stable-alpine-slim", "sha256:abc")
+        content = df.read_text()
+        assert content.startswith("# CascadeGuard Hardened Image")
+        assert "RUN echo hello" in content
+
+
+# ── _resolve_bool_setting ──────────────────────────────────────────────────
+
+from app import _resolve_bool_setting
+
+
+class TestResolveBoolSetting:
+    def test_default_true(self):
+        assert _resolve_bool_setting("promote", {}, {}) is True
+
+    def test_default_false(self):
+        assert _resolve_bool_setting("promote", {}, {}, default=False) is False
+
+    def test_per_image_override_true(self):
+        assert _resolve_bool_setting("promote", {"promote": True}, {}, default=False) is True
+
+    def test_per_image_override_false(self):
+        assert _resolve_bool_setting("promote", {"promote": False}, {}) is False
+
+    def test_repo_level_under_check_section(self):
+        config = {"check": {"promote": False}}
+        assert _resolve_bool_setting("promote", {}, config) is False
+
+    def test_repo_level_top_level(self):
+        config = {"createPr": False}
+        assert _resolve_bool_setting("createPr", {}, config) is False
+        config2 = {"check": {"createPr": False}}
+        assert _resolve_bool_setting("createPr", {}, config2) is False
+
+    def test_per_image_beats_repo_level(self):
+        image = {"promote": True}
+        config = {"check": {"promote": False}}
+        assert _resolve_bool_setting("promote", image, config) is True
+
+    def test_per_image_false_beats_repo_level_true(self):
+        image = {"promote": False}
+        config = {"check": {"promote": True}}
+        assert _resolve_bool_setting("promote", image, config) is False
+
+
+class TestCliPromoteDefaults:
+    """Verify --promote and --create-pr default to None (resolved from config)."""
+
+    def test_promote_default_none(self):
+        from app import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["images", "check"])
+        assert args.promote is None
+
+    def test_no_promote_flag(self):
+        from app import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["images", "check", "--no-promote"])
+        assert args.promote is False
+
+    def test_promote_flag(self):
+        from app import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["images", "check", "--promote"])
+        assert args.promote is True
+
+    def test_create_pr_default_none(self):
+        from app import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["images", "check"])
+        assert args.create_pr is None
+
+    def test_no_create_pr_flag(self):
+        from app import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["images", "check", "--no-create-pr"])
+        assert args.create_pr is False


### PR DESCRIPTION
## Summary

Adds supply chain quarantine to `cg images check`.

### Behaviour (defaults)

Promote and PR creation are **on by default**. The check command now:

1. Detects upstream digest drift (existing behaviour)
2. Evaluates quarantine: `now >= lastUpdated + quarantinePeriod`
3. Pins Dockerfiles for eligible images (`FROM image:tag` → `FROM image:tag@sha256:…`)
4. Opens one PR per base image (dependabot-style) with quarantine details

Use `--no-promote` or `--no-create-pr` to disable, or set in config:

```yaml
# .cascadeguard.yaml
check:
  promote: false
  createPr: false

# or per-image in images.yaml
- name: nginx
  promote: false
```

### Quarantine config hierarchy

1. Built-in default: **48h**
2. `.cascadeguard.yaml`: `quarantine: { period: 24h }` or `quarantine: 24h`
3. Per-image in `images.yaml`: `quarantine: 12h` or `quarantine: disabled`

### New helpers

- `_parse_duration()` — human durations (48h, 7d, 0, disabled)
- `_resolve_quarantine_hours()` — config hierarchy resolution
- `_resolve_bool_setting()` — generic bool config hierarchy (promote, createPr)
- `_update_dockerfile_digest()` — Dockerfile FROM line pinning
- `_create_promotion_pr()` — one PR per base image via platform CLI

### Tests

35 new tests covering duration parsing, config hierarchy, bool settings, CLI flag defaults, and Dockerfile modification. 284 total, all passing.