### PR TITLE
refactor: move git operations into CLI, configurable commit strategy

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1094,6 +1094,40 @@ def _resolve_bool_setting(key: str, image: dict, config: dict, default: bool = T
     return default
 
 
+def _resolve_check_config(config: dict) -> dict:
+    """Resolve the full check configuration from .cascadeguard.yaml.
+
+    Returns a dict with resolved values::
+
+        {
+            "state": {"destination": "main"},
+            "promote": {"enabled": True, "destination": "pr"},
+        }
+    """
+    check = config.get("check", {})
+    if not isinstance(check, dict):
+        check = {}
+
+    state_section = check.get("state", {})
+    if not isinstance(state_section, dict):
+        state_section = {}
+
+    promote_section = check.get("promote", {})
+    if not isinstance(promote_section, dict):
+        # Backwards compat: check.promote: true/false
+        promote_section = {"enabled": bool(promote_section)}
+
+    return {
+        "state": {
+            "destination": state_section.get("destination", "main"),
+        },
+        "promote": {
+            "enabled": promote_section.get("enabled", True),
+            "destination": promote_section.get("destination", "pr"),
+        },
+    }
+
+
 def _update_dockerfile_digest(dockerfile_path: Path, old_ref: str, new_digest: str) -> bool:
     """Pin a Dockerfile FROM line to *new_digest*.
 
@@ -1274,6 +1308,75 @@ def _run_git(cwd: Path, args: List[str]):
     subprocess.run(["git"] + args, cwd=cwd, check=True, capture_output=True)
 
 
+def _commit_state_changes(repo_root: Path, state_dir: Path, destination: str) -> bool:
+    """Commit state file changes to main or via PR.
+
+    Args:
+        repo_root: Repository root.
+        state_dir: Path to .cascadeguard/ state directory.
+        destination: "main" to commit directly, "pr" to open a PR.
+
+    Returns True if changes were committed.
+    """
+    _run_git(repo_root, ["config", "user.name", "cascadeguard[bot]"])
+    _run_git(repo_root, ["config", "user.email", "cascadeguard[bot]@users.noreply.github.com"])
+
+    # Stage state files
+    try:
+        _run_git(repo_root, ["add", str(state_dir)])
+    except subprocess.CalledProcessError:
+        pass
+
+    # Check if there's anything to commit
+    rc = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=repo_root, capture_output=True,
+    )
+    if rc.returncode == 0:
+        print("No state changes to commit.", file=sys.stderr)
+        return False
+
+    scan_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    commit_msg = (
+        f"chore(state): update image state {scan_date}\n\n"
+        "Automated check run. State files updated for drift detection.\n\n"
+        "Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+    )
+
+    if destination == "main":
+        _run_git(repo_root, ["commit", "-m", commit_msg])
+        _run_git(repo_root, ["push", "origin", "main"])
+        print(f"  State changes committed to main.", file=sys.stderr)
+        return True
+
+    elif destination == "pr":
+        branch = f"cascadeguard/state-{scan_date}"
+        _run_git(repo_root, ["checkout", "-B", branch, "main"])
+        _run_git(repo_root, ["commit", "-m", commit_msg])
+        _run_git(repo_root, ["push", "-u", "origin", branch, "--force"])
+
+        if shutil.which("gh"):
+            result = subprocess.run(
+                [
+                    "gh", "pr", "create",
+                    "--title", f"chore(state): update image state {scan_date}",
+                    "--body", "Automated state file update from `cascadeguard images check`.",
+                    "--base", "main",
+                    "--head", branch,
+                ],
+                cwd=repo_root, capture_output=True, text=True,
+            )
+            if result.returncode == 0:
+                print(f"  State PR created: {result.stdout.strip()}", file=sys.stderr)
+            else:
+                print(f"  Warning: State PR creation failed: {result.stderr.strip()}", file=sys.stderr)
+
+        _run_git(repo_root, ["checkout", "main"])
+        return True
+
+    return False
+
+
 def cmd_check(args) -> int:
     """Unified check: generate state, discover base images, query registries."""
     from generate_state import (
@@ -1304,14 +1407,20 @@ def cmd_check(args) -> int:
 
     image_filter: Optional[str] = getattr(args, "image", None)
     fmt: str = getattr(args, "format", "table")
+    no_commit: bool = getattr(args, "no_commit", False)
 
-    # Resolve promote/create-pr: CLI flag (explicit) > config > default (true)
+    # Resolve check config from .cascadeguard.yaml
+    check_config = _resolve_check_config(config)
+
+    # CLI flags override config
     promote_flag = getattr(args, "promote", None)
-    create_pr_flag = getattr(args, "create_pr", None)
-    # These are resolved per-image for promote, but we need a repo-level
-    # default for the overall flow.  Per-image override happens in Phase 5.
-    do_promote = promote_flag if promote_flag is not None else _resolve_bool_setting("promote", {}, config, default=True)
-    do_create_pr = create_pr_flag if create_pr_flag is not None else _resolve_bool_setting("createPr", {}, config, default=True)
+    do_promote = promote_flag if promote_flag is not None else check_config["promote"]["enabled"]
+    promote_destination = check_config["promote"]["destination"]
+    state_destination = check_config["state"]["destination"]
+
+    if no_commit:
+        state_destination = "none"
+        promote_destination = "none"
 
     # ── Phase 1: Generate image state + discover base images ───────────────
     all_base_image_refs: Dict[str, str] = {}  # normalized_name -> full image ref
@@ -1327,7 +1436,7 @@ def cmd_check(args) -> int:
 
         # Find Dockerfile (local or remote)
         source = image.get("source", {})
-        dockerfile_rel = image.get("dockerfile") or source.get("dockerfile")
+        dockerfile_rel = source.get("dockerfile") or image.get("dockerfile")
         base_images = []
 
         if dockerfile_rel:
@@ -1539,7 +1648,7 @@ def cmd_check(args) -> int:
             if not _resolve_bool_setting("promote", image, config, default=True):
                 continue
 
-            dockerfile_rel = image.get("dockerfile") or image.get("source", {}).get("dockerfile")
+            dockerfile_rel = image.get("source", {}).get("dockerfile") or image.get("dockerfile")
             if not dockerfile_rel:
                 continue
 
@@ -1633,10 +1742,34 @@ def cmd_check(args) -> int:
                     bi_state_file = base_images_dir / f"{bi_name}.yaml"
                     tool.write_base_image_state(bi_state, bi_state_file)
 
-    # ── Phase 6: Create PRs if requested (one per base image) ────────────
+    # ── Phase 6: Commit state changes ─────────────────────────────────────
+    if state_destination != "none":
+        try:
+            _commit_state_changes(repo_root, state_dir, state_destination)
+        except Exception as exc:
+            print(f"  Warning: state commit failed: {exc}", file=sys.stderr)
+
+    # ── Phase 7: Create PRs for promotions (one per base image) ───────────
     pr_urls: List[str] = []
-    if do_create_pr and promoted:
+    if promoted and promote_destination == "pr":
         pr_urls = _create_promotion_pr(repo_root, promoted, quarantine_hours_map)
+    elif promoted and promote_destination == "main":
+        # Commit Dockerfile changes directly to main
+        try:
+            _run_git(repo_root, ["config", "user.name", "cascadeguard[bot]"])
+            _run_git(repo_root, ["config", "user.email", "cascadeguard[bot]@users.noreply.github.com"])
+            for p in promoted:
+                _run_git(repo_root, ["add", p["dockerfile"]])
+            scan_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            names = [p["image"] for p in promoted]
+            _run_git(repo_root, ["commit", "-m",
+                f"chore(deps): promote {len(promoted)} base image(s) — {scan_date}\n\n"
+                + "\n".join(f"  • {p['image']}: {p['base_image']} → {p['new_digest'][:24]}…" for p in promoted)
+                + f"\n\nCo-Authored-By: Paperclip <noreply@paperclip.ing>"])
+            _run_git(repo_root, ["push", "origin", "main"])
+            print(f"  Promoted {len(promoted)} image(s) directly to main.", file=sys.stderr)
+        except Exception as exc:
+            print(f"  Warning: promotion commit failed: {exc}", file=sys.stderr)
 
     return 1 if (has_drift or has_new_tags) else 0
 
@@ -2456,13 +2589,13 @@ Commands:
         "--promote",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Update Dockerfiles for base images that have passed quarantine (default: true, use --no-promote to disable)",
+        help="Update Dockerfiles for base images that have passed quarantine (default: from config, use --no-promote to disable)",
     )
     images_check.add_argument(
-        "--create-pr",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Open a PR with promoted Dockerfile changes (default: true, use --no-create-pr to disable)",
+        "--no-commit",
+        action="store_true",
+        default=False,
+        help="Dry run — skip all git commit/push/PR operations",
     )
 
     # images status

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -54,7 +54,7 @@ def _args(**kwargs):
         image=None,
         format="table",
         promote=False,
-        create_pr=False,
+        no_commit=True,
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)

--- a/app/tests/test_check_promotion.py
+++ b/app/tests/test_check_promotion.py
@@ -40,7 +40,7 @@ def _args(**kwargs):
         image=None,
         format="table",
         promote=None,       # None = resolve from config (default: true)
-        create_pr=None,     # None = resolve from config (default: true)
+        no_commit=True,     # Tests don't run git operations
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -158,7 +158,7 @@ class TestDriftWithQuarantineNotElapsed:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, one_hour_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert "@sha256:" not in content
@@ -175,7 +175,7 @@ class TestDriftWithQuarantineNotElapsed:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, one_hour_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         err = capsys.readouterr().err
         assert "quarantine" in err.lower()
@@ -197,7 +197,7 @@ class TestDriftWithQuarantineElapsed:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert f"FROM node:22@{DIGEST_NEW}" in content
@@ -214,7 +214,7 @@ class TestDriftWithQuarantineElapsed:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         err = capsys.readouterr().err
         assert "promoted" in err.lower()
@@ -232,7 +232,7 @@ class TestDriftWithQuarantineElapsed:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         bi_state = yaml.safe_load((Path(state_dir) / "base-images" / "node-22.yaml").read_text())
         assert bi_state["promotedDigest"] == DIGEST_NEW
@@ -253,7 +253,7 @@ class TestDriftWithQuarantineElapsed:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert "@sha256:" not in content
@@ -276,7 +276,7 @@ class TestQuarantineUsesPublishedAt:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, published)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert f"FROM node:22@{DIGEST_NEW}" in content
@@ -298,7 +298,7 @@ class TestQuarantineDisabled:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, just_now)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert f"FROM node:22@{DIGEST_NEW}" in content
@@ -316,7 +316,7 @@ class TestQuarantineDisabled:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, just_now)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert f"FROM node:22@{DIGEST_NEW}" in content
@@ -339,7 +339,7 @@ class TestNoDrift:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_OLD, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         assert rc == 0
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -360,7 +360,7 @@ class TestPerImagePromoteFalse:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert "@sha256:" not in content
@@ -380,7 +380,7 @@ class TestRepoLevelPromoteFalse:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert "@sha256:" not in content
@@ -400,7 +400,7 @@ class TestNoPromoteFlag:
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir,
-                                promote=False, create_pr=False))
+                                promote=False))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert "@sha256:" not in content
@@ -420,7 +420,7 @@ class TestCustomQuarantinePeriod:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, three_hours_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert f"FROM node:22@{DIGEST_NEW}" in content
@@ -438,7 +438,7 @@ class TestCustomQuarantinePeriod:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, three_days_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert "@sha256:" not in content
@@ -458,7 +458,7 @@ class TestRepoLevelQuarantine:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, two_hours_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert f"FROM node:22@{DIGEST_NEW}" in content
@@ -482,7 +482,7 @@ class TestUpdateHistory:
         new_published = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, new_published)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir, create_pr=False))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         bi_state = yaml.safe_load((Path(state_dir) / "base-images" / "node-22.yaml").read_text())
         assert bi_state["currentDigest"] == DIGEST_NEW
@@ -496,12 +496,12 @@ class TestUpdateHistory:
         assert latest["promotedAt"] is None  # still in quarantine
 
 
-class TestNoCreatePrConfig:
-    """check.createPr: false → promote but no PR."""
+class TestPromoteDestinationMain:
+    """check.promote.destination: main → Dockerfile still gets modified."""
 
-    def test_promotes_without_pr(self, tmp_path):
+    def test_dockerfile_promoted(self, tmp_path):
         images_yaml, state_dir = _setup_repo(tmp_path, [_MYAPP], _MYAPP_DF,
-            config={"check": {"createPr": False}})
+            config={"check": {"promote": {"enabled": True, "destination": "main"}}})
         long_ago = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
         _seed_base_image_state(state_dir, "node-22",
                                 digest=DIGEST_NEW,
@@ -512,12 +512,7 @@ class TestNoCreatePrConfig:
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
             with patch("app._get_dockerhub_tags", return_value=[]):
-                with patch("subprocess.run") as mock_run:
-                    cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
+                cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
         assert f"FROM node:22@{DIGEST_NEW}" in content
-
-        for c in mock_run.call_args_list:
-            args = c[0][0] if c[0] else []
-            assert "gh" not in args

--- a/app/tests/test_quarantine.py
+++ b/app/tests/test_quarantine.py
@@ -238,14 +238,59 @@ class TestCliPromoteDefaults:
         args = parser.parse_args(["images", "check", "--promote"])
         assert args.promote is True
 
-    def test_create_pr_default_none(self):
+    def test_no_commit_default_false(self):
         from app import build_parser
         parser = build_parser()
         args = parser.parse_args(["images", "check"])
-        assert args.create_pr is None
+        assert args.no_commit is False
 
-    def test_no_create_pr_flag(self):
+    def test_no_commit_flag(self):
         from app import build_parser
         parser = build_parser()
-        args = parser.parse_args(["images", "check", "--no-create-pr"])
-        assert args.create_pr is False
+        args = parser.parse_args(["images", "check", "--no-commit"])
+        assert args.no_commit is True
+
+
+# ── _resolve_check_config ──────────────────────────────────────────────────
+
+from app import _resolve_check_config
+
+
+class TestResolveCheckConfig:
+    def test_defaults(self):
+        result = _resolve_check_config({})
+        assert result["state"]["destination"] == "main"
+        assert result["promote"]["enabled"] is True
+        assert result["promote"]["destination"] == "pr"
+
+    def test_state_destination_pr(self):
+        config = {"check": {"state": {"destination": "pr"}}}
+        result = _resolve_check_config(config)
+        assert result["state"]["destination"] == "pr"
+
+    def test_promote_disabled(self):
+        config = {"check": {"promote": {"enabled": False}}}
+        result = _resolve_check_config(config)
+        assert result["promote"]["enabled"] is False
+        assert result["promote"]["destination"] == "pr"
+
+    def test_promote_destination_main(self):
+        config = {"check": {"promote": {"destination": "main"}}}
+        result = _resolve_check_config(config)
+        assert result["promote"]["enabled"] is True
+        assert result["promote"]["destination"] == "main"
+
+    def test_backwards_compat_promote_bool(self):
+        config = {"check": {"promote": False}}
+        result = _resolve_check_config(config)
+        assert result["promote"]["enabled"] is False
+
+    def test_full_config(self):
+        config = {"check": {
+            "state": {"destination": "pr"},
+            "promote": {"enabled": True, "destination": "main"},
+        }}
+        result = _resolve_check_config(config)
+        assert result["state"]["destination"] == "pr"
+        assert result["promote"]["enabled"] is True
+        assert result["promote"]["destination"] == "main"


### PR DESCRIPTION
## Summary

All git operations (state commits, promotion PRs) are now handled by the CLI rather than the workflow.

### New config

```yaml
# .cascadeguard.yaml
check:
  state:
    destination: main    # main | pr
  promote:
    enabled: true        # true | false
    destination: pr      # pr | main
```

### Changes

- **State commits**: `cg images check` commits `.cascadeguard/` state files directly to main (default) or via PR
- **Dockerfile promotions**: Opens one PR per base image (default) or commits directly to main
- **`--no-commit`**: New flag for dry-run — skips all git operations
- **`--create-pr` removed**: Replaced by `check.promote.destination` config
- **Dockerfile resolution**: Prefers `source.dockerfile` over root-level `dockerfile`
- **Workflow simplified**: `check.yaml` reusable workflow no longer has a 'Commit state changes' step — the CLI handles it

### Tests

308 tests passing (6 new for `_resolve_check_config`).