### PR TITLE
fix: cache Docker Hub auth, pace requests, check oldest first

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1073,13 +1073,21 @@ _DOCKER_HUB_TAGS_URL = (
 )
 
 
+_dockerhub_auth_cache: Optional[str] = None
+_dockerhub_auth_checked: bool = False
+
+
 def _get_dockerhub_token() -> Optional[str]:
-    """Get Docker Hub auth header value.
+    """Get Docker Hub auth header value (cached).
 
     Uses DOCKERHUB_USERNAME + DOCKERHUB_TOKEN env vars.
-    The PAT can be used directly as HTTP Basic Auth.
-    Returns a Basic auth header value, or None if no credentials.
+    Verifies credentials once, then caches the result.
     """
+    global _dockerhub_auth_cache, _dockerhub_auth_checked
+    if _dockerhub_auth_checked:
+        return _dockerhub_auth_cache
+
+    _dockerhub_auth_checked = True
     username = os.environ.get("DOCKERHUB_USERNAME", "")
     token = os.environ.get("DOCKERHUB_TOKEN", "")
     if not username or not token:
@@ -1095,15 +1103,16 @@ def _get_dockerhub_token() -> Optional[str]:
         with urllib.request.urlopen(req, timeout=10) as resp:
             json.loads(resp.read())
         logger.info(f"Docker Hub: authenticated as {username}")
+        _dockerhub_auth_cache = auth_header
     except Exception as exc:
         logger.warning(f"Docker Hub: auth failed for {username}: {exc}")
-        return None
 
-    return auth_header
+    return _dockerhub_auth_cache
 
 
 def _get_dockerhub_tags(namespace: str, image: str) -> List[str]:
     """Fetch all tags for a Docker Hub image, paginating up to 10 pages."""
+    import time
     url: Optional[str] = _DOCKER_HUB_TAGS_URL.format(namespace=namespace, image=image)
     tags: List[str] = []
     page = 0
@@ -1118,6 +1127,8 @@ def _get_dockerhub_tags(namespace: str, image: str) -> List[str]:
             tags.extend(t["name"] for t in data.get("results", []))
             url = data.get("next") or ""
             page += 1
+            if url:
+                time.sleep(0.2)  # pace requests to avoid 429
     except Exception as exc:
         logger.warning(f"Could not fetch tags for {namespace}/{image}: {exc}")
     return tags
@@ -1660,7 +1671,7 @@ def cmd_check(args) -> int:
             with open(state_file) as f:
                 existing = yaml.safe_load(f) or {}
             # Update lastChecked but preserve runtime data
-            existing["lastChecked"] = datetime.now(timezone.utc).isoformat()
+            # Note: lastChecked is updated in Phase 3 only on successful registry query
             new_state = existing
         else:
             new_state = tool.generate_base_image_state(full_ref)
@@ -1739,23 +1750,40 @@ def cmd_check(args) -> int:
                 tool.write_base_image_state(state, state_file)
 
     # ── Phase 4: Check upstream tags (absorbed from check-upstream) ────────
+    # Sort by lastChecked (oldest first) so rate-limited runs make progress
+    tag_check_images = []
     for image in resolved_images:
         name = image.get("name")
         if not name or not image.get("enabled", True):
             continue
         if image_filter and name != image_filter:
             continue
-
-        # Only check Docker Hub tags for Docker Hub images
         registry = image.get("registry", "")
         if registry and registry not in ("docker.io", "registry-1.docker.io", "index.docker.io", ""):
             continue
+        # Read lastChecked from image state if available
+        img_state_file = images_dir / f"{name}.yaml"
+        last_checked = "9999"  # default: check last
+        if img_state_file.exists():
+            try:
+                with open(img_state_file) as f:
+                    ist = yaml.safe_load(f) or {}
+                last_checked = str(ist.get("lastChecked", "9999"))
+            except Exception:
+                pass
+        tag_check_images.append((last_checked, image))
 
+    tag_check_images.sort(key=lambda x: x[0])
+    rate_limited = False
+
+    for _, image in tag_check_images:
+        if rate_limited:
+            break
+
+        name = image.get("name")
         img_name = image.get("image", name)
         namespace = image.get("namespace", "library")
 
-        # Use full_name if available (e.g. "bitnami/postgresql"),
-        # otherwise construct from namespace/image
         full_name = image.get("full_name", "")
         if full_name and "/" in full_name:
             tag_namespace, tag_image = full_name.split("/", 1)
@@ -1766,6 +1794,11 @@ def cmd_check(args) -> int:
         current_tags: Set[str] = set(image.get("latest_stable_tags", []))
 
         upstream_tags = _get_dockerhub_tags(tag_namespace, tag_image)
+        if not upstream_tags and current_tags:
+            # Likely rate limited — stop processing more images
+            rate_limited = True
+            continue
+
         stable_upstream = {t for t in upstream_tags if _is_stable_tag(t)}
 
         new_tags = stable_upstream - current_tags

--- a/app/tests/test_quarantine.py
+++ b/app/tests/test_quarantine.py
@@ -464,6 +464,11 @@ from types import SimpleNamespace
 
 
 class TestGetDockerHubToken:
+    def setup_method(self):
+        import app
+        app._dockerhub_auth_cache = None
+        app._dockerhub_auth_checked = False
+
     def test_returns_none_without_env_vars(self):
         with patch.dict("os.environ", {}, clear=True):
             assert _get_dockerhub_token() is None
@@ -493,6 +498,10 @@ class TestGetDockerHubToken:
 
 
 class TestGetDockerHubTagsAuth:
+    def setup_method(self):
+        import app
+        app._dockerhub_auth_cache = None
+        app._dockerhub_auth_checked = False
     def test_unauthenticated_request(self):
         """Without credentials, no Authorization header is sent."""
         calls = []
@@ -645,3 +654,89 @@ class TestNamespaceResolution:
                 cmd_check(args)
 
         assert len(tag_calls) == 0
+
+
+class TestRateLimitedIncrementalProgress:
+    """Phase 4 processes oldest-first and stops on rate limit."""
+
+    def setup_method(self):
+        import app
+        app._dockerhub_auth_cache = None
+        app._dockerhub_auth_checked = False
+
+    def test_processes_oldest_first_stops_on_rate_limit(self, tmp_path):
+        """Three images, tag fetch fails on the third. Only first two get checked."""
+        from app import cmd_check
+
+        images_yaml = tmp_path / "images.yaml"
+        images_yaml.write_text(yaml.dump([
+            {"name": "img-old", "image": "old", "tag": "1", "namespace": "library",
+             "latest_stable_tags": ["1.0"]},
+            {"name": "img-mid", "image": "mid", "tag": "1", "namespace": "library",
+             "latest_stable_tags": ["1.0"]},
+            {"name": "img-new", "image": "new", "tag": "1", "namespace": "library",
+             "latest_stable_tags": ["1.0"]},
+        ]))
+        state_dir = tmp_path / ".cascadeguard"
+        images_dir = state_dir / "images"
+        images_dir.mkdir(parents=True)
+
+        # Seed image state with different lastChecked times
+        for name, checked in [("img-old", "2026-01-01"), ("img-mid", "2026-02-01"), ("img-new", "2026-03-01")]:
+            (images_dir / f"{name}.yaml").write_text(yaml.dump({
+                "name": name, "lastChecked": checked,
+                "baseImages": [], "dockerfile": "",
+            }))
+
+        call_order = []
+
+        def mock_get_tags(namespace, image):
+            call_order.append(image)
+            if len(call_order) >= 3:
+                return []  # simulate rate limit (empty = likely rate limited)
+            return ["1.0", "1.1"]
+
+        args = SimpleNamespace(
+            images_yaml=str(images_yaml), state_dir=str(state_dir),
+            image=None, format="table", promote=False, no_commit=True,
+        )
+
+        with patch("app._fetch_manifest_info", return_value=None):
+            with patch("app._get_dockerhub_tags", side_effect=mock_get_tags):
+                cmd_check(args)
+
+        # Should process oldest first
+        assert call_order[0] == "old"
+        assert call_order[1] == "mid"
+        # Third call returns empty → rate_limited flag set → stops
+        assert len(call_order) == 3  # called but got empty result
+
+    def test_images_without_latest_stable_tags_not_rate_limited(self, tmp_path):
+        """Images with no latest_stable_tags don't trigger rate limit detection."""
+        from app import cmd_check
+
+        images_yaml = tmp_path / "images.yaml"
+        images_yaml.write_text(yaml.dump([
+            {"name": "img-a", "image": "a", "tag": "1", "namespace": "library"},
+            {"name": "img-b", "image": "b", "tag": "1", "namespace": "library"},
+        ]))
+        state_dir = tmp_path / ".cascadeguard"
+        state_dir.mkdir(parents=True)
+
+        call_order = []
+
+        def mock_get_tags(namespace, image):
+            call_order.append(image)
+            return []  # empty but no current_tags → not rate limited
+
+        args = SimpleNamespace(
+            images_yaml=str(images_yaml), state_dir=str(state_dir),
+            image=None, format="table", promote=False, no_commit=True,
+        )
+
+        with patch("app._fetch_manifest_info", return_value=None):
+            with patch("app._get_dockerhub_tags", side_effect=mock_get_tags):
+                cmd_check(args)
+
+        # Both should be called — empty result with no current_tags isn't rate limiting
+        assert len(call_order) == 2


### PR DESCRIPTION
Fixes rate limiting for large catalogs. Auth verified once and cached. Images processed oldest-first so rate-limited runs make progress over time.