### PR TITLE
feat(CAS-564): add multi-registry OCI tag fetching for ghcr.io and quay.io

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1642,6 +1642,11 @@ def cmd_check(args) -> int:
         if image_filter and name != image_filter:
             continue
 
+        registry = image.get("registry", "docker.io") or "docker.io"
+        if registry not in {"docker.io", "index.docker.io", "registry-1.docker.io", ""}:
+            logger.debug("skipping state file for %s: registry %s not yet supported", name, registry)
+            continue
+
         # Find Dockerfile (local or remote)
         source = image.get("source", {})
         dockerfile_rel = source.get("dockerfile") or image.get("dockerfile")

--- a/app/app.py
+++ b/app/app.py
@@ -1168,6 +1168,100 @@ def _get_dockerhub_tags_rich(namespace: str, image: str) -> Dict:
     return {"tags": tags, "error": None, "http_status": None}
 
 
+def _get_oci_registry_tags_rich(registry: str, repository: str) -> List[Dict]:
+    """Fetch all tags for an OCI-compliant registry (ghcr.io, quay.io, etc.).
+
+    Uses the OCI Distribution Spec v2 ``/v2/{repository}/tags/list`` endpoint
+    with pagination (RFC 5988 Link header).  Returns a list of dicts in the
+    same format as ``_get_dockerhub_tags_rich``::
+
+        [{"name": "1.0", "digest": None, "last_updated": None}, ...]
+
+    Handles anonymous auth and bearer token auth for ghcr.io
+    (``GHCR_TOKEN`` / ``GITHUB_TOKEN`` env vars) and generic OCI token
+    endpoint for other registries.  Returns ``[]`` on error.
+    """
+    import time
+
+    registry_base = f"https://{registry}"
+    bearer = ""
+    try:
+        if registry == "ghcr.io":
+            ghcr_token = os.environ.get("GHCR_TOKEN") or os.environ.get("GITHUB_TOKEN")
+            creds = f":{ghcr_token}" if ghcr_token else None
+            auth_url = f"https://ghcr.io/token?service=ghcr.io&scope=repository:{repository}:pull"
+            req = urllib.request.Request(auth_url)
+            if creds:
+                import base64
+                req.add_header("Authorization", f"Basic {base64.b64encode(creds.encode()).decode()}")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read())
+            bearer = data.get("token") or data.get("access_token") or ""
+        else:
+            auth_url = f"{registry_base}/v2/token?service={registry}&scope=repository:{repository}:pull"
+            try:
+                with urllib.request.urlopen(auth_url, timeout=10) as resp:
+                    data = json.loads(resp.read())
+                bearer = data.get("token") or data.get("access_token") or ""
+            except Exception:
+                pass  # Proceed unauthenticated (public images on quay.io, etc.)
+    except Exception as exc:
+        logger.debug(f"OCI auth for {registry}/{repository} skipped: {exc}")
+
+    tags: List[Dict] = []
+    url: Optional[str] = f"{registry_base}/v2/{repository}/tags/list?n=100"
+    page = 0
+    while url and page < 10:
+        try:
+            req = urllib.request.Request(url)
+            if bearer:
+                req.add_header("Authorization", f"Bearer {bearer}")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read())
+                link_header = resp.headers.get("Link", "")
+        except Exception as exc:
+            logger.warning(f"Could not fetch tags for {registry}/{repository}: {exc}")
+            break
+
+        for tag_name in (data.get("tags") or []):
+            tags.append({"name": tag_name, "digest": None, "last_updated": None})
+        page += 1
+
+        next_url = None
+        if link_header:
+            for part in link_header.split(","):
+                part = part.strip()
+                if 'rel="next"' in part:
+                    start, end = part.find("<"), part.find(">")
+                    if start != -1 and end != -1:
+                        next_url = part[start + 1:end]
+                        if next_url.startswith("/"):
+                            next_url = f"{registry_base}{next_url}"
+                        break
+        url = next_url
+        if url:
+            time.sleep(0.2)
+
+    return tags
+
+
+def _get_upstream_tags_rich(registry: str, namespace: str, image: str) -> Dict:
+    """Dispatch rich tag fetching to the appropriate registry implementation.
+
+    - ``docker.io`` / empty → Docker Hub API (returns digest + last_updated)
+    - ``ghcr.io``, ``quay.io``, other OCI registries → OCI v2 tags/list
+
+    Returns the same structured dict as ``_get_dockerhub_tags_rich``::
+
+        {"tags": [...], "error": None | "not_found" | "rate_limited" | "network_error", "http_status": ...}
+    """
+    if registry in ("docker.io", "registry-1.docker.io", "index.docker.io", ""):
+        return _get_dockerhub_tags_rich(namespace, image)
+    repository = f"{namespace}/{image}" if namespace else image
+    tags = _get_oci_registry_tags_rich(registry, repository)
+    return {"tags": tags, "error": None, "http_status": None}
+
+
 def _is_stable_tag(tag: str) -> bool:
     """Return True if *tag* looks like a stable release (not RC/nightly/etc.)."""
     skip = {"latest", "edge", "nightly", "testing"}
@@ -1642,11 +1736,6 @@ def cmd_check(args) -> int:
         if image_filter and name != image_filter:
             continue
 
-        registry = image.get("registry", "docker.io") or "docker.io"
-        if registry not in {"docker.io", "index.docker.io", "registry-1.docker.io", ""}:
-            logger.debug("skipping state file for %s: registry %s not yet supported", name, registry)
-            continue
-
         # Find Dockerfile (local or remote)
         source = image.get("source", {})
         dockerfile_rel = source.get("dockerfile") or image.get("dockerfile")
@@ -1798,9 +1887,6 @@ def cmd_check(args) -> int:
             continue
         if image_filter and name != image_filter:
             continue
-        registry = image.get("registry", "")
-        if registry and registry not in ("docker.io", "registry-1.docker.io", "index.docker.io", ""):
-            continue
         # Read lastChecked from image state if available
         img_state_file = images_dir / f"{name}.yaml"
         last_checked = "9999"  # default: check last
@@ -1823,6 +1909,7 @@ def cmd_check(args) -> int:
         name = image.get("name")
         img_name = image.get("image", name)
         namespace = image.get("namespace", "library")
+        registry = image.get("registry", "")
 
         full_name = image.get("full_name", "")
         if full_name and "/" in full_name:
@@ -1848,7 +1935,7 @@ def cmd_check(args) -> int:
         # otherwise fall back to known tags from state file
         current_tags: Set[str] = set(image.get("latest_stable_tags", [])) or known_tag_names
 
-        upstream_result = _get_dockerhub_tags_rich(tag_namespace, tag_image)
+        upstream_result = _get_upstream_tags_rich(registry, tag_namespace, tag_image)
         upstream_tags_rich = upstream_result.get("tags", [])
         upstream_tag_names = [t["name"] for t in upstream_tags_rich]
         fetch_error = upstream_result.get("error")

--- a/app/tests/test_quarantine.py
+++ b/app/tests/test_quarantine.py
@@ -621,8 +621,8 @@ class TestNamespaceResolution:
         assert len(tag_calls) == 1
         assert tag_calls[0] == ("library", "nginx")
 
-    def test_skips_non_dockerhub_registry(self, tmp_path):
-        """Images with ghcr.io registry skip tag checking."""
+    def test_ghcr_registry_uses_oci_not_dockerhub(self, tmp_path):
+        """Images with ghcr.io registry use the OCI fetcher, not Docker Hub API."""
         from app import cmd_check
 
         images_yaml = tmp_path / "images.yaml"
@@ -630,17 +630,22 @@ class TestNamespaceResolution:
             "name": "myapp",
             "image": "myapp",
             "tag": "latest",
-            "registry": "ghcr.io/cascadeguard",
-            "source": {"dockerfile": "images/myapp/Dockerfile"},
+            "namespace": "cascadeguard",
+            "registry": "ghcr.io",
         }]))
         state_dir = tmp_path / ".cascadeguard"
         state_dir.mkdir()
 
-        tag_calls = []
+        dockerhub_calls = []
+        oci_calls = []
 
-        def mock_get_tags(namespace, image):
-            tag_calls.append((namespace, image))
+        def mock_dockerhub(namespace, image):
+            dockerhub_calls.append((namespace, image))
             return {"tags": [], "error": None, "http_status": None}
+
+        def mock_oci(registry, repository):
+            oci_calls.append((registry, repository))
+            return [{"name": "1.0", "digest": None, "last_updated": None}]
 
         args = SimpleNamespace(
             images_yaml=str(images_yaml),
@@ -650,10 +655,13 @@ class TestNamespaceResolution:
         )
 
         with patch("app._fetch_manifest_info", return_value=None):
-            with patch("app._get_dockerhub_tags_rich", side_effect=mock_get_tags):
-                cmd_check(args)
+            with patch("app._get_dockerhub_tags_rich", side_effect=mock_dockerhub):
+                with patch("app._get_oci_registry_tags_rich", side_effect=mock_oci):
+                    cmd_check(args)
 
-        assert len(tag_calls) == 0
+        assert len(dockerhub_calls) == 0, "Docker Hub API must not be called for ghcr.io"
+        assert len(oci_calls) == 1
+        assert oci_calls[0] == ("ghcr.io", "cascadeguard/myapp")
 
 
 class TestRateLimitedIncrementalProgress:
@@ -741,3 +749,143 @@ class TestRateLimitedIncrementalProgress:
 
         # Both should be called — empty result with no current_tags isn't rate limiting
         assert len(call_order) == 2
+
+# ── _get_oci_registry_tags_rich ─────────────────────────────────────────────
+
+
+class TestGetOciRegistryTagsRich:
+    """Unit tests for the OCI Distribution Spec v2 tag-list fetcher."""
+
+    def _make_token_resp(self, token="testtoken"):
+        from unittest.mock import MagicMock
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({"token": token}).encode()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def _make_tags_resp(self, tags, link=None):
+        from unittest.mock import MagicMock
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({"tags": tags}).encode()
+        resp.headers = {"Link": link} if link else {}
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_returns_rich_tag_list(self):
+        from app import _get_oci_registry_tags_rich
+        from unittest.mock import MagicMock
+
+        responses = iter([self._make_token_resp(), self._make_tags_resp(["1.0", "1.1", "2.0"])])
+
+        with patch("urllib.request.urlopen", side_effect=lambda *a, **kw: next(responses)):
+            result = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
+
+        assert len(result) == 3
+        assert all(set(t.keys()) >= {"name", "digest", "last_updated"} for t in result)
+        assert {t["name"] for t in result} == {"1.0", "1.1", "2.0"}
+
+    def test_paginates_via_link_header(self):
+        from app import _get_oci_registry_tags_rich
+        from unittest.mock import MagicMock
+
+        page1 = MagicMock()
+        page1.read.return_value = json.dumps({"tags": ["1.0", "1.1"]}).encode()
+        page1.headers = {"Link": '</v2/myorg/myimage/tags/list?last=1.1&n=100>; rel="next"'}
+        page1.__enter__ = lambda s: s
+        page1.__exit__ = MagicMock(return_value=False)
+
+        responses = iter([self._make_token_resp(), page1, self._make_tags_resp(["2.0", "2.1"])])
+
+        with patch("urllib.request.urlopen", side_effect=lambda *a, **kw: next(responses)):
+            result = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
+
+        assert {t["name"] for t in result} == {"1.0", "1.1", "2.0", "2.1"}
+
+    def test_returns_empty_on_network_error(self):
+        from app import _get_oci_registry_tags_rich
+        import urllib.error
+
+        call_count = [0]
+        resps = [self._make_token_resp(), urllib.error.URLError("refused")]
+
+        def fake_urlopen(*args, **kwargs):
+            v = resps[call_count[0]]
+            call_count[0] += 1
+            if isinstance(v, Exception):
+                raise v
+            return v
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
+
+        assert result == []
+
+    def test_quay_io_proceeds_unauthenticated_on_token_failure(self):
+        from app import _get_oci_registry_tags_rich
+        import urllib.error
+        from unittest.mock import MagicMock
+
+        call_count = [0]
+        resps = [urllib.error.URLError("refused"), self._make_tags_resp(["v1.0"])]
+
+        def fake_urlopen(*args, **kwargs):
+            v = resps[call_count[0]]
+            call_count[0] += 1
+            if isinstance(v, Exception):
+                raise v
+            return v
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result = _get_oci_registry_tags_rich("quay.io", "oauth2-proxy/oauth2-proxy")
+
+        assert {t["name"] for t in result} == {"v1.0"}
+
+
+# ── _get_upstream_tags_rich (dispatcher) ────────────────────────────────────
+
+
+class TestGetUpstreamTagsRich:
+    """Unit tests for the registry dispatcher."""
+
+    def test_dispatches_dockerhub_to_dockerhub_fetcher(self):
+        from app import _get_upstream_tags_rich
+
+        with patch("app._get_dockerhub_tags_rich", return_value=[{"name": "1.0", "digest": None, "last_updated": None}]) as mock_dh:
+            with patch("app._get_oci_registry_tags_rich") as mock_oci:
+                result = _get_upstream_tags_rich("docker.io", "library", "nginx")
+
+        mock_dh.assert_called_once_with("library", "nginx")
+        mock_oci.assert_not_called()
+        assert result[0]["name"] == "1.0"
+
+    def test_dispatches_empty_registry_to_dockerhub(self):
+        from app import _get_upstream_tags_rich
+
+        with patch("app._get_dockerhub_tags_rich", return_value=[]) as mock_dh:
+            with patch("app._get_oci_registry_tags_rich") as mock_oci:
+                _get_upstream_tags_rich("", "library", "postgres")
+
+        mock_dh.assert_called_once_with("library", "postgres")
+        mock_oci.assert_not_called()
+
+    def test_dispatches_ghcr_to_oci_fetcher(self):
+        from app import _get_upstream_tags_rich
+
+        with patch("app._get_dockerhub_tags_rich") as mock_dh:
+            with patch("app._get_oci_registry_tags_rich", return_value=[]) as mock_oci:
+                _get_upstream_tags_rich("ghcr.io", "bitnami", "redis")
+
+        mock_dh.assert_not_called()
+        mock_oci.assert_called_once_with("ghcr.io", "bitnami/redis")
+
+    def test_dispatches_quay_to_oci_fetcher(self):
+        from app import _get_upstream_tags_rich
+
+        with patch("app._get_dockerhub_tags_rich") as mock_dh:
+            with patch("app._get_oci_registry_tags_rich", return_value=[]) as mock_oci:
+                _get_upstream_tags_rich("quay.io", "oauth2-proxy", "oauth2-proxy")
+
+        mock_dh.assert_not_called()
+        mock_oci.assert_called_once_with("quay.io", "oauth2-proxy/oauth2-proxy")


### PR DESCRIPTION
## Summary

Adds OCI registry support so non-Docker-Hub images (ghcr.io, quay.io, etc.) are checked for new tags instead of being silently skipped.

### Changes

- **`_get_oci_registry_tags_rich`** — new function implementing OCI Distribution Spec v2 `/v2/{repo}/tags/list` with pagination and bearer-token auth
- **`_get_upstream_tags_rich`** — dispatcher routing docker.io to Docker Hub and all others to OCI; returns same structured dict shape as `_get_dockerhub_tags_rich`
- **`cmd_check`** — removed early skip for non-Docker-Hub registries; calls `_get_upstream_tags_rich` for all images
- Phase 1 skips state-file creation for non-Docker-Hub registries

Rebased onto main after #106 which changed `_get_dockerhub_tags_rich` to return a structured dict. `_get_upstream_tags_rich` now returns the same shape for both Docker Hub and OCI paths.

Closes CAS-564.