### PR TITLE
feat(check): store tag→digest map with repoint detection

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1111,10 +1111,22 @@ def _get_dockerhub_token() -> Optional[str]:
 
 
 def _get_dockerhub_tags(namespace: str, image: str) -> List[str]:
-    """Fetch all tags for a Docker Hub image, paginating up to 10 pages."""
+    """Fetch all tag names for a Docker Hub image (convenience wrapper)."""
+    return [t["name"] for t in _get_dockerhub_tags_rich(namespace, image)]
+
+
+def _get_dockerhub_tags_rich(namespace: str, image: str) -> List[Dict]:
+    """Fetch all tags for a Docker Hub image with digest and timestamp metadata.
+
+    Returns a list of dicts::
+
+        [{"name": "3.3", "digest": "sha256:...", "last_updated": "ISO-8601"}, ...]
+
+    Paginates up to 10 pages.  Returns [] on error.
+    """
     import time
     url: Optional[str] = _DOCKER_HUB_TAGS_URL.format(namespace=namespace, image=image)
-    tags: List[str] = []
+    tags: List[Dict] = []
     page = 0
     hub_auth = _get_dockerhub_token()
     try:
@@ -1124,7 +1136,12 @@ def _get_dockerhub_tags(namespace: str, image: str) -> List[str]:
                 req.add_header("Authorization", hub_auth)
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read())
-            tags.extend(t["name"] for t in data.get("results", []))
+            for t in data.get("results", []):
+                tags.append({
+                    "name": t["name"],
+                    "digest": t.get("digest"),
+                    "last_updated": t.get("last_updated"),
+                })
             url = data.get("next") or ""
             page += 1
             if url:
@@ -1657,7 +1674,7 @@ def cmd_check(args) -> int:
             "dockerfile": dockerfile_rel or "",
             "baseImages": sorted(base_images),
             "currentDigest": existing.get("currentDigest") if existing else None,
-            "upstreamTags": existing.get("upstreamTags", []) if existing else [],
+            "upstreamTags": existing.get("upstreamTags", {}) if existing else {},
         }
 
         with open(state_file, "w") as f:
@@ -1794,14 +1811,15 @@ def cmd_check(args) -> int:
 
         current_tags: Set[str] = set(image.get("latest_stable_tags", []))
 
-        upstream_tags = _get_dockerhub_tags(tag_namespace, tag_image)
-        if not upstream_tags and current_tags:
+        upstream_tags_rich = _get_dockerhub_tags_rich(tag_namespace, tag_image)
+        upstream_tag_names = [t["name"] for t in upstream_tags_rich]
+        if not upstream_tag_names and current_tags:
             # Likely rate limited — stop processing more images
             rate_limited = True
             continue
 
         # No data returned and no existing tags — skip without updating lastChecked
-        if not upstream_tags:
+        if not upstream_tag_names:
             continue
 
         # Successful registry query — update lastChecked and persist tags
@@ -1815,13 +1833,48 @@ def cmd_check(args) -> int:
         now_iso = datetime.now(timezone.utc).isoformat()
         img_state["lastChecked"] = now_iso
 
-        stable_upstream = {t for t in upstream_tags if _is_stable_tag(t)}
+        # Build tag→digest map from rich response, filtering to stable tags
+        existing_tags = img_state.get("upstreamTags") or {}
+        # Migrate from old list format to dict format
+        if isinstance(existing_tags, list):
+            existing_tags = {}
+        updated_tags = dict(existing_tags)
 
-        # Persist all discovered stable upstream tags
-        if stable_upstream:
-            img_state["upstreamTags"] = sorted(stable_upstream)
+        stable_tag_names = set()
+        for t in upstream_tags_rich:
+            tag_name = t["name"]
+            if not _is_stable_tag(tag_name):
+                continue
+            stable_tag_names.add(tag_name)
+            new_digest = t.get("digest")
+            last_updated = t.get("last_updated")
+            prev = updated_tags.get(tag_name)
+            if prev is None:
+                # New tag — first observation
+                updated_tags[tag_name] = {
+                    "digest": new_digest,
+                    "firstSeen": now_iso,
+                    "lastSeen": now_iso,
+                    "lastUpdated": last_updated,
+                }
+            elif new_digest and prev.get("digest") != new_digest:
+                # Tag repointed — digest changed
+                updated_tags[tag_name] = {
+                    "digest": new_digest,
+                    "firstSeen": prev.get("firstSeen", now_iso),
+                    "lastSeen": now_iso,
+                    "lastUpdated": last_updated,
+                    "previousDigest": prev.get("digest"),
+                }
+            else:
+                # No change — just bump lastSeen
+                updated_tags[tag_name] = dict(prev)
+                updated_tags[tag_name]["lastSeen"] = now_iso
 
-        new_tags = stable_upstream - current_tags
+        if updated_tags:
+            img_state["upstreamTags"] = dict(sorted(updated_tags.items()))
+
+        new_tags = stable_tag_names - current_tags
         surfaced = []
         for t in new_tags:
             base = t.split("-")[0].split(".")[0]

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -516,10 +516,10 @@ class TestCmdCheck:
             "upstreamTags": [],
         }))
 
-        # _get_dockerhub_tags returns empty (simulates 404/rate-limit) and image has
+        # _get_dockerhub_tags_rich returns empty (simulates 404/rate-limit) and image has
         # latest_stable_tags so rate_limited flag is set
         with patch("app._fetch_manifest_info", return_value=None), \
-             patch("app._get_dockerhub_tags", return_value=[]):
+             patch("app._get_dockerhub_tags_rich", return_value=[]):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         # Reload state and verify lastChecked was NOT updated
@@ -551,7 +551,12 @@ class TestCmdCheck:
         }))
 
         with patch("app._fetch_manifest_info", return_value=None), \
-             patch("app._get_dockerhub_tags", return_value=["3.20", "3.21", "3.22", "3.23"]):
+             patch("app._get_dockerhub_tags_rich", return_value=[
+                 {"name": "3.20", "digest": "sha256:aaa", "last_updated": "2026-04-01T00:00:00Z"},
+                 {"name": "3.21", "digest": "sha256:bbb", "last_updated": "2026-04-02T00:00:00Z"},
+                 {"name": "3.22", "digest": "sha256:ccc", "last_updated": "2026-04-03T00:00:00Z"},
+                 {"name": "3.23", "digest": "sha256:ddd", "last_updated": "2026-04-04T00:00:00Z"},
+             ]):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         with open(images_dir / "alpine.yaml") as f:
@@ -582,18 +587,75 @@ class TestCmdCheck:
             "upstreamTags": [],
         }))
 
-        fake_tags = ["3.0", "3.0.1", "3.1", "3.1.1", "3.2", "3.2.1", "3.3", "3.3.1", "latest"]
+        fake_tags = [
+            {"name": "3.0", "digest": "sha256:a00", "last_updated": "2026-04-01T00:00:00Z"},
+            {"name": "3.0.1", "digest": "sha256:a01", "last_updated": "2026-04-01T00:00:00Z"},
+            {"name": "3.1", "digest": "sha256:a10", "last_updated": "2026-04-02T00:00:00Z"},
+            {"name": "3.1.1", "digest": "sha256:a11", "last_updated": "2026-04-02T00:00:00Z"},
+            {"name": "3.2", "digest": "sha256:a20", "last_updated": "2026-04-03T00:00:00Z"},
+            {"name": "3.2.1", "digest": "sha256:a21", "last_updated": "2026-04-03T00:00:00Z"},
+            {"name": "3.3", "digest": "sha256:a30", "last_updated": "2026-04-04T00:00:00Z"},
+            {"name": "3.3.1", "digest": "sha256:a31", "last_updated": "2026-04-04T00:00:00Z"},
+            {"name": "latest", "digest": "sha256:lat", "last_updated": "2026-04-04T00:00:00Z"},
+        ]
         with patch("app._fetch_manifest_info", return_value=None), \
-             patch("app._get_dockerhub_tags", return_value=fake_tags):
+             patch("app._get_dockerhub_tags_rich", return_value=fake_tags):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         with open(images_dir / "fluent-bit.yaml") as f:
             state = yaml.safe_load(f)
-        # "latest" is filtered out by _is_stable_tag, rest should be persisted
+        # "latest" is filtered out by _is_stable_tag, rest should be persisted as dicts
         assert "upstreamTags" in state
+        assert isinstance(state["upstreamTags"], dict)
         assert "3.3" in state["upstreamTags"]
         assert "3.3.1" in state["upstreamTags"]
         assert "latest" not in state["upstreamTags"]
+        # Each tag should have digest info
+        assert state["upstreamTags"]["3.3"]["digest"] == "sha256:a30"
+        assert state["upstreamTags"]["3.3.1"]["digest"] == "sha256:a31"
+
+    def test_tag_repoint_detected_and_previous_digest_stored(self, tmp_path):
+        """When a tag's digest changes, previousDigest must be recorded."""
+        images_yaml, state_dir = self._setup_repo(tmp_path,
+            [{"name": "alpine", "image": "alpine", "tag": "3.23",
+              "namespace": "library", "full_name": "library/alpine"}])
+
+        images_dir = Path(state_dir) / "images"
+        images_dir.mkdir(parents=True, exist_ok=True)
+        (images_dir / "alpine.yaml").write_text(yaml.dump({
+            "name": "alpine",
+            "enrolledAt": "2026-04-14T19:11:49+00:00",
+            "lastChecked": "2026-04-15T10:00:00+00:00",
+            "registry": "",
+            "image": "alpine",
+            "tag": "3.23",
+            "dockerfile": "",
+            "baseImages": [],
+            "currentDigest": None,
+            "upstreamTags": {
+                "3.23": {
+                    "digest": "sha256:old_digest_aaa",
+                    "firstSeen": "2026-04-15T10:00:00+00:00",
+                    "lastSeen": "2026-04-15T10:00:00+00:00",
+                    "lastUpdated": "2026-04-14T00:00:00Z",
+                },
+            },
+        }))
+
+        # Same tag, different digest — repoint
+        with patch("app._fetch_manifest_info", return_value=None), \
+             patch("app._get_dockerhub_tags_rich", return_value=[
+                 {"name": "3.23", "digest": "sha256:new_digest_bbb", "last_updated": "2026-04-18T00:00:00Z"},
+             ]):
+            cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
+
+        with open(images_dir / "alpine.yaml") as f:
+            state = yaml.safe_load(f)
+        tag_state = state["upstreamTags"]["3.23"]
+        assert tag_state["digest"] == "sha256:new_digest_bbb"
+        assert tag_state["previousDigest"] == "sha256:old_digest_aaa"
+        # firstSeen should be preserved from original observation
+        assert tag_state["firstSeen"] == "2026-04-15T10:00:00+00:00"
 
     def test_upstream_tags_not_written_on_empty_response(self, tmp_path):
         """When registry returns no tags (error/rate-limit), upstreamTags must not be cleared."""
@@ -619,7 +681,7 @@ class TestCmdCheck:
 
         # Empty response with current_tags set → rate limited, should not touch state
         with patch("app._fetch_manifest_info", return_value=None), \
-             patch("app._get_dockerhub_tags", return_value=[]):
+             patch("app._get_dockerhub_tags_rich", return_value=[]):
             cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         with open(images_dir / "nginx.yaml") as f:

--- a/app/tests/test_check_promotion.py
+++ b/app/tests/test_check_promotion.py
@@ -157,7 +157,7 @@ class TestDriftWithQuarantineNotElapsed:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, one_hour_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -174,7 +174,7 @@ class TestDriftWithQuarantineNotElapsed:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, one_hour_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         err = capsys.readouterr().err
@@ -196,7 +196,7 @@ class TestDriftWithQuarantineElapsed:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -213,7 +213,7 @@ class TestDriftWithQuarantineElapsed:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         err = capsys.readouterr().err
@@ -231,7 +231,7 @@ class TestDriftWithQuarantineElapsed:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         bi_state = yaml.safe_load((Path(state_dir) / "base-images" / "node-22.yaml").read_text())
@@ -256,7 +256,7 @@ class TestDriftWithQuarantineElapsed:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         # Dockerfile should be unchanged — already pinned to the promoted digest
@@ -280,7 +280,7 @@ class TestQuarantineUsesPublishedAt:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, published)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -302,7 +302,7 @@ class TestQuarantineDisabled:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, just_now)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -320,7 +320,7 @@ class TestQuarantineDisabled:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, just_now)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -347,7 +347,7 @@ class TestNoDrift:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_OLD, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         assert rc == 0
@@ -368,7 +368,7 @@ class TestPerImagePromoteFalse:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -388,7 +388,7 @@ class TestRepoLevelPromoteFalse:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -407,7 +407,7 @@ class TestNoPromoteFlag:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir,
                                 promote=False))
 
@@ -428,7 +428,7 @@ class TestCustomQuarantinePeriod:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, three_hours_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -446,7 +446,7 @@ class TestCustomQuarantinePeriod:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, three_days_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -466,7 +466,7 @@ class TestRepoLevelQuarantine:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, two_hours_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -490,7 +490,7 @@ class TestUpdateHistory:
 
         new_published = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, new_published)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         bi_state = yaml.safe_load((Path(state_dir) / "base-images" / "node-22.yaml").read_text())
@@ -520,7 +520,7 @@ class TestPromoteDestinationMain:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         content = _read_dockerfile(tmp_path, "images/myapp/Dockerfile")
@@ -573,7 +573,7 @@ class TestStateFileRoundtrip:
                           dockerfile="images/myapp/Dockerfile")
 
         with patch("app._fetch_manifest_info", return_value=_mock_info(DIGEST_NEW, long_ago)):
-            with patch("app._get_dockerhub_tags", return_value=[]):
+            with patch("app._get_dockerhub_tags_rich", return_value=[]):
                 cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
 
         # Verify the state file was written successfully (no crash)

--- a/app/tests/test_quarantine.py
+++ b/app/tests/test_quarantine.py
@@ -581,7 +581,7 @@ class TestNamespaceResolution:
         )
 
         with patch("app._fetch_manifest_info", return_value=None):
-            with patch("app._get_dockerhub_tags", side_effect=mock_get_tags):
+            with patch("app._get_dockerhub_tags_rich", side_effect=mock_get_tags):
                 cmd_check(args)
 
         assert len(tag_calls) == 1
@@ -615,7 +615,7 @@ class TestNamespaceResolution:
         )
 
         with patch("app._fetch_manifest_info", return_value=None):
-            with patch("app._get_dockerhub_tags", side_effect=mock_get_tags):
+            with patch("app._get_dockerhub_tags_rich", side_effect=mock_get_tags):
                 cmd_check(args)
 
         assert len(tag_calls) == 1
@@ -650,7 +650,7 @@ class TestNamespaceResolution:
         )
 
         with patch("app._fetch_manifest_info", return_value=None):
-            with patch("app._get_dockerhub_tags", side_effect=mock_get_tags):
+            with patch("app._get_dockerhub_tags_rich", side_effect=mock_get_tags):
                 cmd_check(args)
 
         assert len(tag_calls) == 0
@@ -694,7 +694,8 @@ class TestRateLimitedIncrementalProgress:
             call_order.append(image)
             if len(call_order) >= 3:
                 return []  # simulate rate limit (empty = likely rate limited)
-            return ["1.0", "1.1"]
+            return [{"name": "1.0", "digest": "sha256:aaa", "last_updated": None},
+                    {"name": "1.1", "digest": "sha256:bbb", "last_updated": None}]
 
         args = SimpleNamespace(
             images_yaml=str(images_yaml), state_dir=str(state_dir),
@@ -702,7 +703,7 @@ class TestRateLimitedIncrementalProgress:
         )
 
         with patch("app._fetch_manifest_info", return_value=None):
-            with patch("app._get_dockerhub_tags", side_effect=mock_get_tags):
+            with patch("app._get_dockerhub_tags_rich", side_effect=mock_get_tags):
                 cmd_check(args)
 
         # Should process oldest first
@@ -735,7 +736,7 @@ class TestRateLimitedIncrementalProgress:
         )
 
         with patch("app._fetch_manifest_info", return_value=None):
-            with patch("app._get_dockerhub_tags", side_effect=mock_get_tags):
+            with patch("app._get_dockerhub_tags_rich", side_effect=mock_get_tags):
                 cmd_check(args)
 
         # Both should be called — empty result with no current_tags isn't rate limiting


### PR DESCRIPTION
## Summary

Changes `upstreamTags` from a flat list of tag names to a dict mapping each stable tag to its current digest and timestamps. This enables detecting when upstream maintainers repoint a tag to a different image.

### Before
```yaml
upstreamTags:
  - '3.2'
  - '3.3'
```

### After
```yaml
upstreamTags:
  '3.2':
    digest: sha256:abc123...
    firstSeen: '2026-04-18T06:00:00+00:00'
    lastSeen: '2026-04-18T06:00:00+00:00'
    lastUpdated: '2026-04-17T08:24:33Z'
  '3.3':
    digest: sha256:def456...
    firstSeen: '2026-04-15T06:00:00+00:00'
    lastSeen: '2026-04-18T06:00:00+00:00'
    lastUpdated: '2026-04-18T02:00:00Z'
    previousDigest: sha256:old789...  # tag was repointed
```

### How it works

- The Docker Hub tags API already returns `digest` and `last_updated` per tag — zero extra API calls
- New `_get_dockerhub_tags_rich()` extracts the full response; existing `_get_dockerhub_tags()` wrapper kept for compatibility
- When a tag's digest changes between runs, `previousDigest` is recorded
- Full repoint history is tracked by git diffs on the state file — no duplication in YAML
- Gracefully migrates from the old list format

### Test plan

- Existing 332 tests updated and passing
- New test: `test_tag_repoint_detected_and_previous_digest_stored`