### PR TITLE
feat(CAS-540): apply .cascadeguard.yaml defaults in generate_state.py

### DIFF
--- a/app/generate_state.py
+++ b/app/generate_state.py
@@ -31,6 +31,39 @@ def load_config(output_dir: Path) -> dict:
     return {}
 
 
+def merge_defaults(images: list, config: dict) -> list:
+    """Apply repo-level defaults from .cascadeguard.yaml to each image.
+
+    Per-image values always take precedence over config defaults.
+    Only these keys are inherited: registry, repository, local.dir.
+    Does NOT mutate the input list or its dicts.
+    """
+    defaults = config.get("defaults", {})
+    if not defaults:
+        return [dict(img) for img in images]
+
+    default_registry = defaults.get("registry")
+    default_repository = defaults.get("repository")
+    default_local = defaults.get("local", {})
+    default_local_dir = default_local.get("dir")
+
+    result = []
+    for img in images:
+        merged = dict(img)
+        if "registry" not in merged and default_registry:
+            merged["registry"] = default_registry
+        if "repository" not in merged and default_repository:
+            merged["repository"] = default_repository
+        if default_local_dir:
+            img_local = merged.get("local", {})
+            if "dir" not in img_local:
+                merged_local = dict(img_local)
+                merged_local["dir"] = default_local_dir
+                merged["local"] = merged_local
+        result.append(merged)
+    return result
+
+
 def resolve_tagging(image: dict, config: dict) -> dict:
     """
     Resolve tagging configuration by merging repo-level defaults with
@@ -856,8 +889,9 @@ def main():
     images = load_images_yaml(args.images_yaml)
     print(f"Found {len(images)} images in {args.images_yaml}")
 
-    # Load repo-level config (.cascadeguard.yaml)
+    # Load repo-level config (.cascadeguard.yaml) and apply defaults
     config = load_config(args.output_dir)
+    images = merge_defaults(images, config)
 
     # Generate state for each image
     success_count = 0

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -549,6 +549,70 @@ class TestGenerateBuildWorkflow:
         assert result2 is False
 
 
+class TestMergeDefaultsInGenerateState:
+    """Tests that generate_state.merge_defaults applies .cascadeguard.yaml defaults."""
+
+    def setup_method(self):
+        from generate_state import merge_defaults
+        self.merge_defaults = merge_defaults
+
+    def test_no_defaults_section_returns_copies(self):
+        images = [{"name": "app", "registry": "ghcr.io"}]
+        result = self.merge_defaults(images, {})
+        assert result == images
+        assert result is not images  # returns copies
+
+    def test_default_registry_applied(self):
+        images = [{"name": "app"}]
+        config = {"defaults": {"registry": "ghcr.io/myorg"}}
+        result = self.merge_defaults(images, config)
+        assert result[0]["registry"] == "ghcr.io/myorg"
+
+    def test_per_image_registry_wins(self):
+        images = [{"name": "app", "registry": "docker.io"}]
+        config = {"defaults": {"registry": "ghcr.io/myorg"}}
+        result = self.merge_defaults(images, config)
+        assert result[0]["registry"] == "docker.io"
+
+    def test_default_local_dir_applied(self):
+        images = [{"name": "app"}]
+        config = {"defaults": {"local": {"dir": "images"}}}
+        result = self.merge_defaults(images, config)
+        assert result[0]["local"]["dir"] == "images"
+
+    def test_per_image_local_dir_wins(self):
+        images = [{"name": "app", "local": {"dir": "custom/path"}}]
+        config = {"defaults": {"local": {"dir": "images"}}}
+        result = self.merge_defaults(images, config)
+        assert result[0]["local"]["dir"] == "custom/path"
+
+    def test_local_dir_default_does_not_overwrite_other_local_keys(self):
+        images = [{"name": "app", "local": {"patchFiles": ["a.patch"]}}]
+        config = {"defaults": {"local": {"dir": "images"}}}
+        result = self.merge_defaults(images, config)
+        assert result[0]["local"]["dir"] == "images"
+        assert result[0]["local"]["patchFiles"] == ["a.patch"]
+
+    def test_default_repository_applied(self):
+        images = [{"name": "app"}]
+        config = {"defaults": {"repository": "myorg/app"}}
+        result = self.merge_defaults(images, config)
+        assert result[0]["repository"] == "myorg/app"
+
+    def test_does_not_mutate_input(self):
+        original = {"name": "app"}
+        images = [original]
+        config = {"defaults": {"registry": "ghcr.io/myorg", "local": {"dir": "images"}}}
+        self.merge_defaults(images, config)
+        assert "registry" not in original
+        assert "local" not in original
+
+    def test_empty_defaults_section_is_noop(self):
+        images = [{"name": "app"}]
+        result = self.merge_defaults(images, {"defaults": {}})
+        assert result[0] == {"name": "app"}
+
+
 class TestActionsPinner:
     """Unit tests for ActionsPinner."""
 


### PR DESCRIPTION
## Summary

- Adds `merge_defaults()` to `generate_state.py` and calls it in `main()` after loading images and config
- Ensures `defaults.registry`, `defaults.repository`, and `defaults.local.dir` from `.cascadeguard.yaml` are applied to all images before state files and build workflows are generated
- Previously only `cmd_validate` and `cmd_check` honoured these defaults; the `generate_state.py` script (invoked by `Taskfile.docker.yaml` `generate` task) ignored them entirely
- 9 unit tests added covering all default-inheritance cases and the no-mutation guarantee

## Test plan

- [ ] `pytest tests/test_app.py::TestMergeDefaultsInGenerateState` — 9 new tests all pass
- [ ] Full suite `pytest tests/` — 353 passed

## Paperclip issue

[CAS-540](/CAS/issues/CAS-540)

🤖 Generated with [Claude Code](https://claude.com/claude-code)