### PR TITLE
fix(check): use exit code 2 for updates-available signal

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2271,7 +2271,10 @@ def cmd_check(args) -> int:
             print(f"  ✗ {err}", file=sys.stderr)
         return 1
 
-    return 1 if (has_drift or has_new_tags) else 0
+    # Exit 2 = updates available (new tags/drift detected — informational, not an error).
+    # Exit 1 = genuine error (config problem, promotion failure, etc.).
+    # Exit 0 = no updates.
+    return 2 if (has_drift or has_new_tags) else 0
 
 
 def cmd_build(args) -> int:

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -363,7 +363,8 @@ class TestCmdCheck:
 
     # ── drift detected ───────────────────────────────────────────────────────
 
-    def test_drift_base_image_returns_1(self, tmp_path):
+    def test_drift_base_image_returns_2(self, tmp_path):
+        # Drift = "updates available" → exit 2 (not a genuine error).
         images_yaml, state_dir = self._setup_repo(tmp_path,
             [{"name": "myapp", "dockerfile": "images/myapp/Dockerfile", "image": "myapp", "tag": "latest", "registry": "ghcr.io"}],
             {"images/myapp/Dockerfile": "FROM node:22\nRUN echo hello\n"})
@@ -371,7 +372,7 @@ class TestCmdCheck:
 
         with patch("app._fetch_manifest_info", return_value={"digest": DIGEST_B, "publishedAt": None}):
             rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
-        assert rc == 1
+        assert rc == 2
 
     def test_drift_table_output(self, tmp_path, capsys):
         images_yaml, state_dir = self._setup_repo(tmp_path,

--- a/app/tests/test_check_exit_codes.py
+++ b/app/tests/test_check_exit_codes.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for cmd_check exit code contract.
+
+Exit codes:
+  0 — no updates found
+  1 — genuine error (bad config, etc.)
+  2 — updates available (new tags or digest drift detected)
+"""
+
+import os
+import sys
+import yaml
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app import cmd_check
+
+
+def _args(tmp_path, **kwargs):
+    defaults = dict(
+        images_yaml=str(tmp_path / "images.yaml"),
+        state_dir=str(tmp_path / ".cascadeguard"),
+        image=None,
+        format="table",
+        promote=None,
+        no_commit=True,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _write_images_yaml(tmp_path, images):
+    p = tmp_path / "images.yaml"
+    p.write_text(yaml.dump(images))
+    Path(tmp_path / ".cascadeguard").mkdir(exist_ok=True)
+
+
+_HELLO_WORLD = {
+    "name": "hello-world",
+    "registry": "docker.io",
+    "image": "hello-world",
+    "namespace": "library",
+    "tag": "latest",
+}
+
+_STABLE_TAGS = [
+    {"name": "v1.0", "digest": "sha256:" + "a" * 64, "last_updated": "2025-01-01T00:00:00Z"},
+    {"name": "v1.1", "digest": "sha256:" + "b" * 64, "last_updated": "2025-01-02T00:00:00Z"},
+]
+
+
+class TestCheckExitCodes:
+    def test_exit_0_when_no_updates(self, tmp_path):
+        """Exit 0 when all upstream tags are already known."""
+        _write_images_yaml(tmp_path, [_HELLO_WORLD])
+        # Pre-seed state with the tags that the mock will return
+        img_state_dir = tmp_path / ".cascadeguard" / "images"
+        img_state_dir.mkdir(parents=True, exist_ok=True)
+        state = {
+            "upstreamTags": {
+                "v1.0": {"digest": "sha256:" + "a" * 64, "firstSeen": "2025-01-01T00:00:00Z", "lastSeen": "2025-01-01T00:00:00Z", "lastUpdated": "2025-01-01T00:00:00Z"},
+                "v1.1": {"digest": "sha256:" + "b" * 64, "firstSeen": "2025-01-02T00:00:00Z", "lastSeen": "2025-01-02T00:00:00Z", "lastUpdated": "2025-01-02T00:00:00Z"},
+            }
+        }
+        (img_state_dir / "hello-world.yaml").write_text(yaml.dump(state))
+
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _STABLE_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                rc = cmd_check(_args(tmp_path))
+
+        assert rc == 0
+
+    def test_exit_2_when_new_tags_found(self, tmp_path):
+        """Exit 2 when upstream returns tags not yet in state."""
+        _write_images_yaml(tmp_path, [_HELLO_WORLD])
+        # No existing state — all tags are new
+
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _STABLE_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                rc = cmd_check(_args(tmp_path))
+
+        assert rc == 2
+
+    def test_exit_1_when_images_yaml_missing(self, tmp_path):
+        """Exit 1 when images.yaml does not exist."""
+        rc = cmd_check(_args(tmp_path, images_yaml=str(tmp_path / "nonexistent.yaml")))
+        assert rc == 1


### PR DESCRIPTION
Previously cmd_check returned exit code 1 for both genuine errors (missing config, promotion failures) and the informational "updates available" case (new tags or digest drift detected). CI systems like GitLab have no way to distinguish these.

Introduce exit code 2 = "updates available" so CI pipelines can treat it explicitly as a non-error outcome without using allow_failure:

  cascadeguard images check; CG_EXIT=$?
  [ "$CG_EXIT" -eq 2 ] && exit 0 || exit "$CG_EXIT"

Exit codes:
  0 — no updates found
  1 — genuine error (bad config, promotion failure, etc.)
  2 — updates available (new tags or drift detected)