### PR TITLE
feat(check): platform-aware state PR/MR via REST API, drop gh CLI from _commit_state_changes

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -198,7 +198,7 @@ tasks:
           if [ -n "$CI" ]; then
             python -m pytest tests/test_app.py tests/test_cascadeguard.py tests/test_hooks.py tests/test_scan.py tests/test_scan_issues_api.py tests/test_actions_policy.py tests/test_tools_check.py tests/test_tools_enroll.py tests/test_promotion_pr_api.py -v
           else
-            .venv/bin/python -m pytest tests/test_app.py tests/test_cascadeguard.py tests/test_hooks.py tests/test_scan.py tests/test_scan_issues_api.py tests/test_actions_policy.py tests/test_tools_check.py tests/test_tools_enroll.py -v
+            .venv/bin/python -m pytest tests/test_app.py tests/test_cascadeguard.py tests/test_hooks.py tests/test_scan.py tests/test_scan_issues_api.py tests/test_actions_policy.py tests/test_tools_check.py tests/test_tools_enroll.py tests/test_promotion_pr_api.py -v
           fi
 
   cdk8s:test:unit:

--- a/app/app.py
+++ b/app/app.py
@@ -1844,18 +1844,30 @@ def _run_git(cwd: Path, args: List[str]):
     subprocess.run(["git"] + args, cwd=cwd, check=True, capture_output=True)
 
 
-def _commit_state_changes(repo_root: Path, state_dir: Path, destination: str) -> bool:
-    """Commit state file changes to main or via PR.
+def _commit_state_changes(
+    repo_root: Path,
+    state_dir: Path,
+    destination: str,
+    ci_platform: str = "github",
+) -> bool:
+    """Commit state file changes to main or via PR/MR.
 
     Args:
         repo_root: Repository root.
         state_dir: Path to .cascadeguard/ state directory.
-        destination: "main" to commit directly, "pr" to open a PR.
+        destination: "main" to commit directly, "pr" to open a PR/MR.
+        ci_platform: "github" (default) or "gitlab".
 
     Returns True if changes were committed.
     """
+    is_gitlab = ci_platform == "gitlab"
+    bot_email = (
+        "cascadeguard[bot]@users.noreply.gitlab.com"
+        if is_gitlab
+        else "cascadeguard[bot]@users.noreply.github.com"
+    )
     _run_git(repo_root, ["config", "user.name", "cascadeguard[bot]"])
-    _run_git(repo_root, ["config", "user.email", "cascadeguard[bot]@users.noreply.github.com"])
+    _run_git(repo_root, ["config", "user.email", bot_email])
 
     # Stage state files
     try:
@@ -1891,21 +1903,60 @@ def _commit_state_changes(repo_root: Path, state_dir: Path, destination: str) ->
         _run_git(repo_root, ["commit", "-m", commit_msg])
         _run_git(repo_root, ["push", "-u", "origin", branch, "--force"])
 
-        if shutil.which("gh"):
-            result = subprocess.run(
-                [
-                    "gh", "pr", "create",
-                    "--title", f"chore(state): update image state {scan_date}",
-                    "--body", "Automated state file update from `cascadeguard images check`.",
-                    "--base", "main",
-                    "--head", branch,
-                ],
-                cwd=repo_root, capture_output=True, text=True,
-            )
-            if result.returncode == 0:
-                print(f"  State PR created: {result.stdout.strip()}", file=sys.stderr)
+        pr_title = f"chore(state): update image state {scan_date}"
+        pr_body = "Automated state file update from `cascadeguard images check`."
+
+        if is_gitlab:
+            token = os.environ.get("CI_JOB_TOKEN") or os.environ.get("GITLAB_TOKEN")
+            project_id = os.environ.get("CI_PROJECT_ID") or os.environ.get("CI_PROJECT_PATH")
+            server_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+            if token and project_id:
+                encoded = urllib.parse.quote(str(project_id), safe="")
+                data, err = _gitlab_api(
+                    "POST",
+                    f"projects/{encoded}/merge_requests",
+                    token,
+                    server_url,
+                    {
+                        "title": pr_title,
+                        "description": pr_body,
+                        "source_branch": branch,
+                        "target_branch": "main",
+                    },
+                )
+                if data:
+                    print(f"  State MR created: {data.get('web_url', '')}", file=sys.stderr)
+                else:
+                    print(f"  Warning: State MR creation failed: {err}", file=sys.stderr)
             else:
-                print(f"  Warning: State PR creation failed: {result.stderr.strip()}", file=sys.stderr)
+                print(
+                    "  Warning: CI_JOB_TOKEN/GITLAB_TOKEN or CI_PROJECT_ID not set; skipping state MR.",
+                    file=sys.stderr,
+                )
+        else:
+            token = os.environ.get("GITHUB_TOKEN")
+            repo = _github_repo(repo_root)
+            if token and repo:
+                data, err = _github_api(
+                    "POST",
+                    f"https://api.github.com/repos/{repo}/pulls",
+                    token,
+                    {
+                        "title": pr_title,
+                        "body": pr_body,
+                        "base": "main",
+                        "head": branch,
+                    },
+                )
+                if data:
+                    print(f"  State PR created: {data.get('html_url', '')}", file=sys.stderr)
+                else:
+                    print(f"  Warning: State PR creation failed: {err}", file=sys.stderr)
+            else:
+                print(
+                    "  Warning: GITHUB_TOKEN or repo not found; skipping state PR.",
+                    file=sys.stderr,
+                )
 
         _run_git(repo_root, ["checkout", "main"])
         return True
@@ -1953,6 +2004,7 @@ def cmd_check(args) -> int:
     do_promote = promote_flag if promote_flag is not None else check_config["promote"]["enabled"]
     promote_destination = check_config["promote"]["destination"]
     state_destination = check_config["state"]["destination"]
+    ci_platform = config.get("ci", {}).get("platform", "github")
 
     if no_commit:
         state_destination = "none"
@@ -2415,7 +2467,7 @@ def cmd_check(args) -> int:
     # ── Phase 6: Commit state changes ─────────────────────────────────────
     if state_destination != "none":
         try:
-            _commit_state_changes(repo_root, state_dir, state_destination)
+            _commit_state_changes(repo_root, state_dir, state_destination, ci_platform)
         except Exception as exc:
             print(f"  Warning: state commit failed: {exc}", file=sys.stderr)
 
@@ -2492,7 +2544,6 @@ def cmd_check(args) -> int:
     pr_urls: List[str] = []
     pr_errors: List[str] = []
     if promoted and promote_destination == "pr":
-        ci_platform = config.get("ci", {}).get("platform", "github")
         pr_urls, pr_errors = _create_promotion_pr(repo_root, promoted, quarantine_hours_map, ci_platform)
     elif promoted and promote_destination == "main":
         try:

--- a/app/tests/test_promotion_pr_api.py
+++ b/app/tests/test_promotion_pr_api.py
@@ -7,6 +7,8 @@ Covers:
   - _gitlab_api   — correct auth headers, JSON parse, HTTP error handling
   - _create_promotion_pr(ci_platform="github") — no token skip, create PR, update PR
   - _create_promotion_pr(ci_platform="gitlab") — no token skip, create MR, update MR
+  - _commit_state_changes(ci_platform="github") — no changes, commit to main, create PR
+  - _commit_state_changes(ci_platform="gitlab") — create MR, no token skip
 """
 
 import json
@@ -23,6 +25,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app import (
+    _commit_state_changes,
     _create_promotion_pr,
     _github_api,
     _github_repo,
@@ -346,3 +349,103 @@ class TestCreatePromotionPrGitLab:
         assert pr_urls == []
         assert len(pr_errors) == 1
         assert "node:22" in pr_errors[0]
+
+
+# ── _commit_state_changes ───────────────────────────────────────────────────
+
+
+def _make_state_dir(tmp_path):
+    state_dir = tmp_path / ".cascadeguard"
+    state_dir.mkdir()
+    (state_dir / "state.yaml").write_text("images: {}")
+    return state_dir
+
+
+def _git_no_changes():
+    """subprocess.run mock: git diff --cached --quiet returns 0 (nothing staged)."""
+    return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _git_has_changes():
+    """subprocess.run mock: git diff --cached --quiet returns 1 (changes staged)."""
+    return SimpleNamespace(returncode=1, stdout="diff", stderr="")
+
+
+class TestCommitStateChangesNoChanges:
+    def test_returns_false_when_nothing_staged(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_no_changes()):
+            result = _commit_state_changes(tmp_path, state_dir, "main")
+        assert result is False
+
+
+class TestCommitStateChangesMainDestination:
+    def test_commits_and_pushes_to_main(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        with patch("app._run_git") as mock_git, \
+             patch("subprocess.run", return_value=_git_has_changes()):
+            result = _commit_state_changes(tmp_path, state_dir, "main")
+
+        assert result is True
+        calls = [str(c) for c in mock_git.call_args_list]
+        assert any("push" in c and "main" in c for c in calls)
+
+
+class TestCommitStateChangesPrGitHub:
+    def test_creates_pr_via_github_api(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "myorg/myrepo")
+        state_dir = _make_state_dir(tmp_path)
+        new_pr = {"number": 99, "html_url": "https://github.com/myorg/myrepo/pull/99"}
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_has_changes()), \
+             patch("urllib.request.urlopen", return_value=_fake_response(new_pr)):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="github")
+
+        assert result is True
+
+    def test_skips_pr_when_no_github_token(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        state_dir = _make_state_dir(tmp_path)
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", side_effect=[
+                 _git_has_changes(),            # diff --cached
+                 SimpleNamespace(returncode=0, stdout="", stderr=""),  # git remote get-url
+             ]):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="github")
+
+        assert result is True  # branch pushed; PR creation just skipped
+        assert "GITHUB_TOKEN" in capsys.readouterr().err
+
+
+class TestCommitStateChangesPrGitLab:
+    def test_creates_mr_via_gitlab_api(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CI_JOB_TOKEN", "jobtoken")
+        monkeypatch.setenv("CI_PROJECT_ID", "42")
+        monkeypatch.setenv("CI_SERVER_URL", "https://gitlab.example.com")
+        state_dir = _make_state_dir(tmp_path)
+        new_mr = {"iid": 5, "web_url": "https://gitlab.example.com/o/r/-/merge_requests/5"}
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_has_changes()), \
+             patch("urllib.request.urlopen", return_value=_fake_response(new_mr)):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="gitlab")
+
+        assert result is True
+
+    def test_skips_mr_when_no_token(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("CI_JOB_TOKEN", raising=False)
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        monkeypatch.setenv("CI_PROJECT_ID", "42")
+        state_dir = _make_state_dir(tmp_path)
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_has_changes()):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="gitlab")
+
+        assert result is True  # branch pushed; MR creation just skipped
+        assert "CI_JOB_TOKEN" in capsys.readouterr().err


### PR DESCRIPTION
Replace shutil.which("gh") in _commit_state_changes with the same platform-aware REST-API approach used in _create_promotion_pr:
- GitLab: POST projects/{id}/merge_requests via CI_JOB_TOKEN/GITLAB_TOKEN
- GitHub: POST repos/{owner}/{repo}/pulls via GITHUB_TOKEN + _github_repo()
- ci_platform extracted once in cmd_check and threaded through both callers
- 6 new unit tests in test_promotion_pr_api.py (27 total, all green)