### PR TITLE
fix(check): skip Phase 4 tag check for self-built images; propagate OCI 404 errors

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -198,7 +198,7 @@ tasks:
           if [ -n "$CI" ]; then
             python -m pytest tests/test_app.py tests/test_cascadeguard.py tests/test_hooks.py tests/test_scan.py tests/test_scan_issues_api.py tests/test_actions_policy.py tests/test_tools_check.py tests/test_tools_enroll.py tests/test_promotion_pr_api.py -v
           else
-            .venv/bin/python -m pytest tests/test_app.py tests/test_cascadeguard.py tests/test_hooks.py tests/test_scan.py tests/test_scan_issues_api.py tests/test_actions_policy.py tests/test_tools_check.py tests/test_tools_enroll.py -v
+            .venv/bin/python -m pytest tests/test_app.py tests/test_cascadeguard.py tests/test_hooks.py tests/test_scan.py tests/test_scan_issues_api.py tests/test_actions_policy.py tests/test_tools_check.py tests/test_tools_enroll.py tests/test_promotion_pr_api.py -v
           fi
 
   cdk8s:test:unit:

--- a/app/app.py
+++ b/app/app.py
@@ -1263,18 +1263,20 @@ def _get_dockerhub_tags_rich(namespace: str, image: str) -> Dict:
     return {"tags": tags, "error": None, "http_status": None}
 
 
-def _get_oci_registry_tags_rich(registry: str, repository: str) -> List[Dict]:
+def _get_oci_registry_tags_rich(registry: str, repository: str) -> Tuple[List[Dict], Optional[str]]:
     """Fetch all tags for an OCI-compliant registry (ghcr.io, quay.io, etc.).
 
     Uses the OCI Distribution Spec v2 ``/v2/{repository}/tags/list`` endpoint
-    with pagination (RFC 5988 Link header).  Returns a list of dicts in the
-    same format as ``_get_dockerhub_tags_rich``::
+    with pagination (RFC 5988 Link header).  Returns a tuple of
+    ``(tags, error)`` where error is one of ``None``, ``"not_found"``,
+    ``"network_error"``.  Tags have the same format as
+    ``_get_dockerhub_tags_rich``::
 
         [{"name": "1.0", "digest": None, "last_updated": None}, ...]
 
     Handles anonymous auth and bearer token auth for ghcr.io
     (``GHCR_TOKEN`` / ``GITHUB_TOKEN`` env vars) and generic OCI token
-    endpoint for other registries.  Returns ``[]`` on error.
+    endpoint for other registries.
     """
     import time
 
@@ -1314,9 +1316,15 @@ def _get_oci_registry_tags_rich(registry: str, repository: str) -> List[Dict]:
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read())
                 link_header = resp.headers.get("Link", "")
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                logger.warning(f"Not found: {registry}/{repository} (404)")
+                return tags, "not_found"
+            logger.warning(f"Could not fetch tags for {registry}/{repository}: {exc}")
+            return tags, "network_error"
         except Exception as exc:
             logger.warning(f"Could not fetch tags for {registry}/{repository}: {exc}")
-            break
+            return tags, "network_error"
 
         for tag_name in (data.get("tags") or []):
             tags.append({"name": tag_name, "digest": None, "last_updated": None})
@@ -1337,7 +1345,7 @@ def _get_oci_registry_tags_rich(registry: str, repository: str) -> List[Dict]:
         if url:
             time.sleep(0.2)
 
-    return tags
+    return tags, None
 
 
 def _get_upstream_tags_rich(registry: str, namespace: str, image: str) -> Dict:
@@ -1353,8 +1361,8 @@ def _get_upstream_tags_rich(registry: str, namespace: str, image: str) -> Dict:
     if registry in ("docker.io", "registry-1.docker.io", "index.docker.io", ""):
         return _get_dockerhub_tags_rich(namespace, image)
     repository = f"{namespace}/{image}" if namespace else image
-    tags = _get_oci_registry_tags_rich(registry, repository)
-    return {"tags": tags, "error": None, "http_status": None}
+    tags, error = _get_oci_registry_tags_rich(registry, repository)
+    return {"tags": tags, "error": error, "http_status": None}
 
 
 def _is_stable_tag(tag: str) -> bool:
@@ -2196,6 +2204,13 @@ def cmd_check(args) -> int:
         img_name = image.get("image", name)
         namespace = image.get("namespace", "library")
         registry = image.get("registry", "")
+
+        # Self-built images (those with a Dockerfile source) are tracked via
+        # base-image digest in Phase 3; checking their own registry for upstream
+        # tags is not meaningful and will fail for private/custom registries.
+        _source = image.get("source", {})
+        if _source.get("dockerfile") or image.get("dockerfile"):
+            continue
 
         full_name = image.get("full_name", "")
         if full_name and "/" in full_name:

--- a/app/app.py
+++ b/app/app.py
@@ -1844,18 +1844,30 @@ def _run_git(cwd: Path, args: List[str]):
     subprocess.run(["git"] + args, cwd=cwd, check=True, capture_output=True)
 
 
-def _commit_state_changes(repo_root: Path, state_dir: Path, destination: str) -> bool:
-    """Commit state file changes to main or via PR.
+def _commit_state_changes(
+    repo_root: Path,
+    state_dir: Path,
+    destination: str,
+    ci_platform: str = "github",
+) -> bool:
+    """Commit state file changes to main or via PR/MR.
 
     Args:
         repo_root: Repository root.
         state_dir: Path to .cascadeguard/ state directory.
-        destination: "main" to commit directly, "pr" to open a PR.
+        destination: "main" to commit directly, "pr" to open a PR/MR.
+        ci_platform: "github" (default) or "gitlab".
 
     Returns True if changes were committed.
     """
+    is_gitlab = ci_platform == "gitlab"
+    bot_email = (
+        "cascadeguard[bot]@users.noreply.gitlab.com"
+        if is_gitlab
+        else "cascadeguard[bot]@users.noreply.github.com"
+    )
     _run_git(repo_root, ["config", "user.name", "cascadeguard[bot]"])
-    _run_git(repo_root, ["config", "user.email", "cascadeguard[bot]@users.noreply.github.com"])
+    _run_git(repo_root, ["config", "user.email", bot_email])
 
     # Stage state files
     try:
@@ -1891,21 +1903,60 @@ def _commit_state_changes(repo_root: Path, state_dir: Path, destination: str) ->
         _run_git(repo_root, ["commit", "-m", commit_msg])
         _run_git(repo_root, ["push", "-u", "origin", branch, "--force"])
 
-        if shutil.which("gh"):
-            result = subprocess.run(
-                [
-                    "gh", "pr", "create",
-                    "--title", f"chore(state): update image state {scan_date}",
-                    "--body", "Automated state file update from `cascadeguard images check`.",
-                    "--base", "main",
-                    "--head", branch,
-                ],
-                cwd=repo_root, capture_output=True, text=True,
-            )
-            if result.returncode == 0:
-                print(f"  State PR created: {result.stdout.strip()}", file=sys.stderr)
+        pr_title = f"chore(state): update image state {scan_date}"
+        pr_body = "Automated state file update from `cascadeguard images check`."
+
+        if is_gitlab:
+            token = os.environ.get("CI_JOB_TOKEN") or os.environ.get("GITLAB_TOKEN")
+            project_id = os.environ.get("CI_PROJECT_ID") or os.environ.get("CI_PROJECT_PATH")
+            server_url = os.environ.get("CI_SERVER_URL", "https://gitlab.com")
+            if token and project_id:
+                encoded = urllib.parse.quote(str(project_id), safe="")
+                data, err = _gitlab_api(
+                    "POST",
+                    f"projects/{encoded}/merge_requests",
+                    token,
+                    server_url,
+                    {
+                        "title": pr_title,
+                        "description": pr_body,
+                        "source_branch": branch,
+                        "target_branch": "main",
+                    },
+                )
+                if data:
+                    print(f"  State MR created: {data.get('web_url', '')}", file=sys.stderr)
+                else:
+                    print(f"  Warning: State MR creation failed: {err}", file=sys.stderr)
             else:
-                print(f"  Warning: State PR creation failed: {result.stderr.strip()}", file=sys.stderr)
+                print(
+                    "  Warning: CI_JOB_TOKEN/GITLAB_TOKEN or CI_PROJECT_ID not set; skipping state MR.",
+                    file=sys.stderr,
+                )
+        else:
+            token = os.environ.get("GITHUB_TOKEN")
+            repo = _github_repo(repo_root)
+            if token and repo:
+                data, err = _github_api(
+                    "POST",
+                    f"https://api.github.com/repos/{repo}/pulls",
+                    token,
+                    {
+                        "title": pr_title,
+                        "body": pr_body,
+                        "base": "main",
+                        "head": branch,
+                    },
+                )
+                if data:
+                    print(f"  State PR created: {data.get('html_url', '')}", file=sys.stderr)
+                else:
+                    print(f"  Warning: State PR creation failed: {err}", file=sys.stderr)
+            else:
+                print(
+                    "  Warning: GITHUB_TOKEN or repo not found; skipping state PR.",
+                    file=sys.stderr,
+                )
 
         _run_git(repo_root, ["checkout", "main"])
         return True
@@ -1953,6 +2004,7 @@ def cmd_check(args) -> int:
     do_promote = promote_flag if promote_flag is not None else check_config["promote"]["enabled"]
     promote_destination = check_config["promote"]["destination"]
     state_destination = check_config["state"]["destination"]
+    ci_platform = config.get("ci", {}).get("platform", "github")
 
     if no_commit:
         state_destination = "none"
@@ -2415,7 +2467,7 @@ def cmd_check(args) -> int:
     # ── Phase 6: Commit state changes ─────────────────────────────────────
     if state_destination != "none":
         try:
-            _commit_state_changes(repo_root, state_dir, state_destination)
+            _commit_state_changes(repo_root, state_dir, state_destination, ci_platform)
         except Exception as exc:
             print(f"  Warning: state commit failed: {exc}", file=sys.stderr)
 
@@ -2492,7 +2544,6 @@ def cmd_check(args) -> int:
     pr_urls: List[str] = []
     pr_errors: List[str] = []
     if promoted and promote_destination == "pr":
-        ci_platform = config.get("ci", {}).get("platform", "github")
         pr_urls, pr_errors = _create_promotion_pr(repo_root, promoted, quarantine_hours_map, ci_platform)
     elif promoted and promote_destination == "main":
         try:

--- a/app/tests/test_cascadeguard.py
+++ b/app/tests/test_cascadeguard.py
@@ -888,6 +888,35 @@ class TestCmdCheck:
         )
 
 
+    def test_phase4_skipped_for_self_built_image(self, tmp_path):
+        """Phase 4 tag check must be skipped for images with a source.dockerfile.
+
+        Self-built images are tracked via base-image digest (Phase 3).  Trying
+        to fetch their own tags from a private registry (e.g. GitLab) causes
+        spurious 404 errors that are then misidentified as rate-limiting,
+        blocking subsequent images.
+        """
+        dockerfile_path = "local/hello-world/Dockerfile"
+        images_yaml, state_dir = self._setup_repo(tmp_path, [
+            {
+                "name": "hello-world",
+                "image": "hello-world",
+                "tag": "latest",
+                "registry": "registry.gitlab.com/cascadeguard/cascadeguard-exemplar-web-argocd",
+                "source": {"dockerfile": dockerfile_path},
+            }
+        ], {dockerfile_path: "FROM nginx:1.28.3-alpine3.23\n"})
+
+        # _get_dockerhub_tags_rich / _get_oci_registry_tags_rich must NOT be
+        # called; if they are it means Phase 4 ran for the self-built image.
+        with patch("app._fetch_manifest_info", return_value={"digest": "sha256:aabbcc", "publishedAt": None}), \
+             patch("app._get_dockerhub_tags_rich", side_effect=AssertionError("Phase 4 ran for self-built image")), \
+             patch("app._get_oci_registry_tags_rich", side_effect=AssertionError("Phase 4 ran for self-built image")):
+            rc = cmd_check(_args(images_yaml=images_yaml, state_dir=state_dir))
+
+        assert rc in (0, 2), f"cmd_check exited {rc}"
+
+
 # ---------------------------------------------------------------------------
 # cmd_status
 # ---------------------------------------------------------------------------

--- a/app/tests/test_promotion_pr_api.py
+++ b/app/tests/test_promotion_pr_api.py
@@ -7,6 +7,8 @@ Covers:
   - _gitlab_api   — correct auth headers, JSON parse, HTTP error handling
   - _create_promotion_pr(ci_platform="github") — no token skip, create PR, update PR
   - _create_promotion_pr(ci_platform="gitlab") — no token skip, create MR, update MR
+  - _commit_state_changes(ci_platform="github") — no changes, commit to main, create PR
+  - _commit_state_changes(ci_platform="gitlab") — create MR, no token skip
 """
 
 import json
@@ -23,6 +25,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from app import (
+    _commit_state_changes,
     _create_promotion_pr,
     _github_api,
     _github_repo,
@@ -346,3 +349,103 @@ class TestCreatePromotionPrGitLab:
         assert pr_urls == []
         assert len(pr_errors) == 1
         assert "node:22" in pr_errors[0]
+
+
+# ── _commit_state_changes ───────────────────────────────────────────────────
+
+
+def _make_state_dir(tmp_path):
+    state_dir = tmp_path / ".cascadeguard"
+    state_dir.mkdir()
+    (state_dir / "state.yaml").write_text("images: {}")
+    return state_dir
+
+
+def _git_no_changes():
+    """subprocess.run mock: git diff --cached --quiet returns 0 (nothing staged)."""
+    return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _git_has_changes():
+    """subprocess.run mock: git diff --cached --quiet returns 1 (changes staged)."""
+    return SimpleNamespace(returncode=1, stdout="diff", stderr="")
+
+
+class TestCommitStateChangesNoChanges:
+    def test_returns_false_when_nothing_staged(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_no_changes()):
+            result = _commit_state_changes(tmp_path, state_dir, "main")
+        assert result is False
+
+
+class TestCommitStateChangesMainDestination:
+    def test_commits_and_pushes_to_main(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        with patch("app._run_git") as mock_git, \
+             patch("subprocess.run", return_value=_git_has_changes()):
+            result = _commit_state_changes(tmp_path, state_dir, "main")
+
+        assert result is True
+        calls = [str(c) for c in mock_git.call_args_list]
+        assert any("push" in c and "main" in c for c in calls)
+
+
+class TestCommitStateChangesPrGitHub:
+    def test_creates_pr_via_github_api(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "myorg/myrepo")
+        state_dir = _make_state_dir(tmp_path)
+        new_pr = {"number": 99, "html_url": "https://github.com/myorg/myrepo/pull/99"}
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_has_changes()), \
+             patch("urllib.request.urlopen", return_value=_fake_response(new_pr)):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="github")
+
+        assert result is True
+
+    def test_skips_pr_when_no_github_token(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        state_dir = _make_state_dir(tmp_path)
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", side_effect=[
+                 _git_has_changes(),            # diff --cached
+                 SimpleNamespace(returncode=0, stdout="", stderr=""),  # git remote get-url
+             ]):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="github")
+
+        assert result is True  # branch pushed; PR creation just skipped
+        assert "GITHUB_TOKEN" in capsys.readouterr().err
+
+
+class TestCommitStateChangesPrGitLab:
+    def test_creates_mr_via_gitlab_api(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CI_JOB_TOKEN", "jobtoken")
+        monkeypatch.setenv("CI_PROJECT_ID", "42")
+        monkeypatch.setenv("CI_SERVER_URL", "https://gitlab.example.com")
+        state_dir = _make_state_dir(tmp_path)
+        new_mr = {"iid": 5, "web_url": "https://gitlab.example.com/o/r/-/merge_requests/5"}
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_has_changes()), \
+             patch("urllib.request.urlopen", return_value=_fake_response(new_mr)):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="gitlab")
+
+        assert result is True
+
+    def test_skips_mr_when_no_token(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("CI_JOB_TOKEN", raising=False)
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        monkeypatch.setenv("CI_PROJECT_ID", "42")
+        state_dir = _make_state_dir(tmp_path)
+
+        with patch("app._run_git"), \
+             patch("subprocess.run", return_value=_git_has_changes()):
+            result = _commit_state_changes(tmp_path, state_dir, "pr", ci_platform="gitlab")
+
+        assert result is True  # branch pushed; MR creation just skipped
+        assert "CI_JOB_TOKEN" in capsys.readouterr().err

--- a/app/tests/test_quarantine.py
+++ b/app/tests/test_quarantine.py
@@ -645,7 +645,7 @@ class TestNamespaceResolution:
 
         def mock_oci(registry, repository):
             oci_calls.append((registry, repository))
-            return [{"name": "1.0", "digest": None, "last_updated": None}]
+            return [{"name": "1.0", "digest": None, "last_updated": None}], None
 
         args = SimpleNamespace(
             images_yaml=str(images_yaml),
@@ -780,11 +780,12 @@ class TestGetOciRegistryTagsRich:
         responses = iter([self._make_token_resp(), self._make_tags_resp(["1.0", "1.1", "2.0"])])
 
         with patch("urllib.request.urlopen", side_effect=lambda *a, **kw: next(responses)):
-            result = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
+            tags, error = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
 
-        assert len(result) == 3
-        assert all(set(t.keys()) >= {"name", "digest", "last_updated"} for t in result)
-        assert {t["name"] for t in result} == {"1.0", "1.1", "2.0"}
+        assert error is None
+        assert len(tags) == 3
+        assert all(set(t.keys()) >= {"name", "digest", "last_updated"} for t in tags)
+        assert {t["name"] for t in tags} == {"1.0", "1.1", "2.0"}
 
     def test_paginates_via_link_header(self):
         from app import _get_oci_registry_tags_rich
@@ -799,9 +800,10 @@ class TestGetOciRegistryTagsRich:
         responses = iter([self._make_token_resp(), page1, self._make_tags_resp(["2.0", "2.1"])])
 
         with patch("urllib.request.urlopen", side_effect=lambda *a, **kw: next(responses)):
-            result = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
+            tags, error = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
 
-        assert {t["name"] for t in result} == {"1.0", "1.1", "2.0", "2.1"}
+        assert error is None
+        assert {t["name"] for t in tags} == {"1.0", "1.1", "2.0", "2.1"}
 
     def test_returns_empty_on_network_error(self):
         from app import _get_oci_registry_tags_rich
@@ -818,9 +820,10 @@ class TestGetOciRegistryTagsRich:
             return v
 
         with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-            result = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
+            tags, error = _get_oci_registry_tags_rich("ghcr.io", "myorg/myimage")
 
-        assert result == []
+        assert error == "network_error"
+        assert tags == []
 
     def test_quay_io_proceeds_unauthenticated_on_token_failure(self):
         from app import _get_oci_registry_tags_rich
@@ -838,9 +841,10 @@ class TestGetOciRegistryTagsRich:
             return v
 
         with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-            result = _get_oci_registry_tags_rich("quay.io", "oauth2-proxy/oauth2-proxy")
+            tags, error = _get_oci_registry_tags_rich("quay.io", "oauth2-proxy/oauth2-proxy")
 
-        assert {t["name"] for t in result} == {"v1.0"}
+        assert error is None
+        assert {t["name"] for t in tags} == {"v1.0"}
 
 
 # ── _get_upstream_tags_rich (dispatcher) ────────────────────────────────────
@@ -874,7 +878,7 @@ class TestGetUpstreamTagsRich:
         from app import _get_upstream_tags_rich
 
         with patch("app._get_dockerhub_tags_rich") as mock_dh:
-            with patch("app._get_oci_registry_tags_rich", return_value=[]) as mock_oci:
+            with patch("app._get_oci_registry_tags_rich", return_value=([], None)) as mock_oci:
                 _get_upstream_tags_rich("ghcr.io", "bitnami", "redis")
 
         mock_dh.assert_not_called()
@@ -884,7 +888,7 @@ class TestGetUpstreamTagsRich:
         from app import _get_upstream_tags_rich
 
         with patch("app._get_dockerhub_tags_rich") as mock_dh:
-            with patch("app._get_oci_registry_tags_rich", return_value=[]) as mock_oci:
+            with patch("app._get_oci_registry_tags_rich", return_value=([], None)) as mock_oci:
                 _get_upstream_tags_rich("quay.io", "oauth2-proxy", "oauth2-proxy")
 
         mock_dh.assert_not_called()


### PR DESCRIPTION
## Summary

- **Bug 1 (primary)**: Phase 4 upstream tag check was running for self-built images (those with `source.dockerfile`). For the GitLab exemplar the default `library` namespace was prepended to the GitLab registry path, producing a 404 that was swallowed and misidentified as rate-limiting, stopping all further processing.
- **Bug 2**: `_get_oci_registry_tags_rich` returned a bare list; callers could not distinguish 404 from an empty result or rate-limit.

## Changes

- Phase 4 skips images with `source.dockerfile` or `dockerfile` — base-image drift for these is tracked by Phase 3.
- `_get_oci_registry_tags_rich` now returns `(tags, error)` where error is `None | "not_found" | "network_error"`.
- `_get_upstream_tags_rich` propagates the OCI error through the structured dict format.
- New test `test_phase4_skipped_for_self_built_image` verifies OCI/DockerHub fetchers are never called for self-built images.
- All existing mocks updated for the new return signature (470 tests, all passing).

## Test plan

- [x] `pytest tests/ -q` — 470 passed
- [ ] Verify GitLab exemplar CI no longer reports spurious rate-limit for hello-world

Closes: CAS-595

Note: MR creation 401 (CI_JOB_TOKEN lacks api scope) is addressed in cascadeguard-ci-templates.