### PR TITLE
feat(CAS-605): post-run hook point + job summary for new tag count

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -843,6 +843,73 @@ def _run_hooks(
     return merged
 
 
+def _run_post_run_hooks(
+    config: dict,
+    repo_root: Path,
+    state_dir: Path,
+    results: list,
+    total_new_tag_count: int,
+) -> None:
+    """Invoke configured post-run hooks once after all images are processed.
+
+    Unlike post-image-check hooks, post-run hooks fire once per check run.
+    The hook receives a summary payload and the state directory path so it
+    can read ALL state files. Hook stdout is ignored (no state to merge).
+    """
+    hook_entries = config.get("hooks", {}).get("post-run", [])
+    if not hook_entries:
+        return
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    stdin_payload = json.dumps({
+        "hookPoint": "post-run",
+        "results": results,
+        "summary": {
+            "totalImages": len(results),
+            "newTagCount": total_new_tag_count,
+        },
+        "stateDir": str(state_dir),
+        "timestamp": timestamp,
+    })
+
+    for entry in hook_entries:
+        if not isinstance(entry, dict):
+            print("  hook config: entry must be a mapping — skipping", file=sys.stderr)
+            continue
+
+        hook_path_raw = entry.get("path")
+        if not hook_path_raw:
+            print("  hook config: missing 'path' — skipping entry", file=sys.stderr)
+            continue
+
+        hook_path = repo_root / hook_path_raw
+        if not hook_path.resolve().is_relative_to(repo_root.resolve()):
+            print(f"  hook path outside repo root: {hook_path_raw} — skipping", file=sys.stderr)
+            continue
+        if not hook_path.exists():
+            print(f"  hook not found: {hook_path} — skipping", file=sys.stderr)
+            continue
+
+        try:
+            result = subprocess.run(
+                [str(hook_path)],
+                input=stdin_payload,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                cwd=str(repo_root),
+            )
+        except subprocess.TimeoutExpired:
+            print(f"  post-run hook timed out (60s): {hook_path_raw}", file=sys.stderr)
+            continue
+        except Exception as exc:
+            print(f"  post-run hook error ({hook_path_raw}): {exc}", file=sys.stderr)
+            continue
+
+        if result.returncode != 0:
+            snippet = result.stderr.strip()[:200]
+            print(f"  post-run hook exit {result.returncode} ({hook_path_raw}): {snippet}", file=sys.stderr)
+
 def merge_defaults(images: list, config: dict) -> list:
     """Apply repo-level defaults from .cascadeguard.yaml to each image.
 
@@ -2373,6 +2440,22 @@ def cmd_check(args) -> int:
                     print(f"  ? {img}: {r['reason']}")
                 elif status == "skipped":
                     print(f"  - {img}: skipped ({r['reason']})")
+
+    # ── Job summary (new tag count) ──────────────────────────────────────
+    total_new_tag_count = sum(len(r.get("new_tags", [])) for r in results if r.get("status") == "new-tags")
+    images_checked = len([r for r in results if r.get("status") not in ("skipped",)])
+    summary_line = f"CascadeGuard check: {images_checked} image(s) checked, {total_new_tag_count} new upstream tag(s) found"
+    print(f"\n{summary_line}", file=sys.stderr)
+    step_summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary_path:
+        try:
+            with open(step_summary_path, "a") as _sf:
+                _sf.write(f"\n## CascadeGuard\n\n- {summary_line}\n")
+        except OSError:
+            pass
+
+    # ── Post-run hooks ─────────────────────────────────────────────────────
+    _run_post_run_hooks(config, repo_root, state_dir, results, total_new_tag_count)
 
     # ── Phase 5: Promote images past quarantine ────────────────────────────
     promoted: List[Dict] = []

--- a/app/tests/test_check_job_summary.py
+++ b/app/tests/test_check_job_summary.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Integration tests for cmd_check job summary and post-run hook point.
+
+Covers:
+- New tag count summary printed to stderr after check
+- GITHUB_STEP_SUMMARY written when env var is set
+- Post-run hooks invoked with correct payload (hookPoint, stateDir, summary)
+- Post-run hook skipped when none configured
+- Zero-new-tags run still prints summary line
+"""
+
+import json
+import os
+import stat
+import sys
+import yaml
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app import cmd_check
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+_IMAGE = {
+    "name": "nginx",
+    "registry": "docker.io",
+    "image": "nginx",
+    "namespace": "library",
+    "tag": "latest",
+}
+
+_NEW_TAGS = [
+    {"name": "1.27", "digest": "sha256:" + "a" * 64, "last_updated": "2026-04-01T00:00:00Z"},
+    {"name": "1.28", "digest": "sha256:" + "b" * 64, "last_updated": "2026-04-02T00:00:00Z"},
+]
+
+
+def _args(tmp_path, **kwargs):
+    defaults = dict(
+        images_yaml=str(tmp_path / "images.yaml"),
+        state_dir=str(tmp_path / ".cascadeguard"),
+        image=None,
+        format="table",
+        promote=None,
+        no_commit=True,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _setup(tmp_path, images=None, config=None):
+    """Write images.yaml and create state directory."""
+    (tmp_path / ".cascadeguard").mkdir(exist_ok=True)
+    (tmp_path / ".cascadeguard" / "images").mkdir(parents=True, exist_ok=True)
+    images_yaml = tmp_path / "images.yaml"
+    images_yaml.write_text(yaml.dump(images or [_IMAGE]))
+    if config:
+        (tmp_path / ".cascadeguard.yaml").write_text(yaml.dump(config))
+
+
+def _make_hook(tmp_path, name: str, script: str) -> str:
+    """Write an executable shell script; return its path relative to tmp_path."""
+    path = tmp_path / name
+    path.write_text(f"#!/bin/sh\n{script}\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return name  # relative path for config
+
+
+# ── Job summary (stderr) ───────────────────────────────────────────────────
+
+
+class TestJobSummaryStderr:
+    def test_summary_printed_when_new_tags_found(self, tmp_path, capsys):
+        _setup(tmp_path)
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+
+        captured = capsys.readouterr()
+        assert "2 new upstream tag" in captured.err
+        assert "CascadeGuard check" in captured.err
+
+    def test_summary_printed_when_no_new_tags(self, tmp_path, capsys):
+        _setup(tmp_path)
+        # Pre-seed state so all tags are already known
+        state = {
+            "upstreamTags": {
+                t["name"]: {"digest": t["digest"], "firstSeen": "2026-01-01T00:00:00Z",
+                             "lastSeen": "2026-01-01T00:00:00Z", "lastUpdated": t["last_updated"]}
+                for t in _NEW_TAGS
+            }
+        }
+        (tmp_path / ".cascadeguard" / "images" / "nginx.yaml").write_text(yaml.dump(state))
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+
+        captured = capsys.readouterr()
+        assert "CascadeGuard check" in captured.err
+        assert "0 new upstream tag" in captured.err
+
+    def test_new_tag_count_matches_actual_new_tags(self, tmp_path, capsys):
+        _setup(tmp_path)
+        # Seed one tag as known, one is new
+        state = {
+            "upstreamTags": {
+                "1.27": {"digest": "sha256:" + "a" * 64, "firstSeen": "2026-01-01T00:00:00Z",
+                          "lastSeen": "2026-01-01T00:00:00Z", "lastUpdated": "2026-04-01T00:00:00Z"},
+            }
+        }
+        (tmp_path / ".cascadeguard" / "images" / "nginx.yaml").write_text(yaml.dump(state))
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+
+        captured = capsys.readouterr()
+        assert "1 new upstream tag" in captured.err
+
+
+# ── GITHUB_STEP_SUMMARY ────────────────────────────────────────────────────
+
+
+class TestGithubStepSummary:
+    def test_summary_written_to_step_summary_file(self, tmp_path, monkeypatch):
+        summary_file = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        _setup(tmp_path)
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+
+        assert summary_file.exists()
+        content = summary_file.read_text()
+        assert "CascadeGuard" in content
+        assert "new upstream tag" in content
+
+    def test_no_step_summary_without_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        _setup(tmp_path)
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+        # No file should have been created in tmp_path (beyond what setup wrote)
+        assert not (tmp_path / "summary.md").exists()
+
+    def test_step_summary_appended_not_overwritten(self, tmp_path, monkeypatch):
+        summary_file = tmp_path / "summary.md"
+        summary_file.write_text("## Prior content\n\n")
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        _setup(tmp_path)
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+
+        content = summary_file.read_text()
+        assert "Prior content" in content
+        assert "CascadeGuard" in content
+
+
+# ── Post-run hook invocation ───────────────────────────────────────────────
+
+
+class TestPostRunHookInvocation:
+    def test_post_run_hook_called_with_correct_hook_point(self, tmp_path):
+        captured_file = tmp_path / "hook-payload.json"
+        hook_name = _make_hook(
+            tmp_path, "capture.sh", f"cat > {captured_file}"
+        )
+        config = {"hooks": {"post-run": [{"path": f"./{hook_name}"}]}}
+        _setup(tmp_path, config=config)
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+
+        payload = json.loads(captured_file.read_text())
+        assert payload["hookPoint"] == "post-run"
+
+    def test_post_run_hook_receives_new_tag_count(self, tmp_path):
+        captured_file = tmp_path / "hook-payload.json"
+        hook_name = _make_hook(
+            tmp_path, "capture.sh", f"cat > {captured_file}"
+        )
+        config = {"hooks": {"post-run": [{"path": f"./{hook_name}"}]}}
+        _setup(tmp_path, config=config)
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path))
+
+        payload = json.loads(captured_file.read_text())
+        assert payload["summary"]["newTagCount"] == 2
+
+    def test_post_run_hook_receives_state_dir(self, tmp_path):
+        captured_file = tmp_path / "hook-payload.json"
+        hook_name = _make_hook(
+            tmp_path, "capture.sh", f"cat > {captured_file}"
+        )
+        config = {"hooks": {"post-run": [{"path": f"./{hook_name}"}]}}
+        _setup(tmp_path, config=config)
+        state_dir = str(tmp_path / ".cascadeguard")
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                cmd_check(_args(tmp_path, state_dir=state_dir))
+
+        payload = json.loads(captured_file.read_text())
+        assert payload["stateDir"] == state_dir
+
+    def test_post_run_hook_not_called_when_not_configured(self, tmp_path):
+        """No post-run hooks in config → _run_post_run_hooks is still called but does nothing."""
+        _setup(tmp_path)
+        with patch("app._run_post_run_hooks") as mock_hook:
+            with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+                with patch("app._fetch_manifest_info", return_value=None):
+                    cmd_check(_args(tmp_path))
+        # Should have been called once with the correct args
+        mock_hook.assert_called_once()
+        call_kwargs = mock_hook.call_args
+        assert call_kwargs.args[4] == 2  # total_new_tag_count
+
+    def test_post_run_hook_failure_does_not_abort_check(self, tmp_path):
+        hook_name = _make_hook(tmp_path, "fail.sh", "exit 1")
+        config = {"hooks": {"post-run": [{"path": f"./{hook_name}"}]}}
+        _setup(tmp_path, config=config)
+        with patch("app._get_upstream_tags_rich", return_value={"tags": _NEW_TAGS, "error": None, "http_status": None}):
+            with patch("app._fetch_manifest_info", return_value=None):
+                rc = cmd_check(_args(tmp_path))
+        # Check still exits 2 (new tags), not 1 (error)
+        assert rc == 2

--- a/app/tests/test_hooks.py
+++ b/app/tests/test_hooks.py
@@ -196,3 +196,71 @@ class TestRunHooks:
         ):
             result = _run_hooks("post-image-check", config, tmp_path, {}, state, {})
         assert result == state
+
+from app import _run_post_run_hooks
+
+
+class TestRunPostRunHooks:
+
+    def test_no_hooks_returns_without_error(self, tmp_path):
+        # Should silently do nothing when no post-run hooks configured
+        _run_post_run_hooks({}, tmp_path, tmp_path, [], 0)
+
+    def test_hook_receives_correct_payload(self, tmp_path):
+        # Hook dumps the received hookPoint and newTagCount back to a file
+        out_file = tmp_path / "received.json"
+        hook = tmp_path / "capture.sh"
+        hook.write_text(
+            f"#!/bin/sh\n"
+            f"cat > {out_file}\n"
+        )
+        hook.chmod(hook.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        config = {"hooks": {"post-run": [{"path": "capture.sh"}]}}
+        results = [{"image": "nginx", "status": "new-tags", "new_tags": ["1.28", "1.29"]}]
+        _run_post_run_hooks(config, tmp_path, tmp_path / "state", results, 2)
+
+        received = json.loads(out_file.read_text())
+        assert received["hookPoint"] == "post-run"
+        assert received["summary"]["newTagCount"] == 2
+        assert received["summary"]["totalImages"] == 1
+        assert received["stateDir"] == str(tmp_path / "state")
+
+    def test_hook_failure_does_not_raise(self, tmp_path):
+        _make_hook(tmp_path, "fail.sh", "exit 1")
+        config = {"hooks": {"post-run": [{"path": "fail.sh"}]}}
+        # Should not raise even on hook failure
+        _run_post_run_hooks(config, tmp_path, tmp_path, [], 0)
+
+    def test_hook_timeout_does_not_raise(self, tmp_path):
+        _make_hook(tmp_path, "slow.sh", "sleep 999")
+        config = {"hooks": {"post-run": [{"path": "slow.sh"}]}}
+        with unittest.mock.patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="slow.sh", timeout=60),
+        ):
+            _run_post_run_hooks(config, tmp_path, tmp_path, [], 0)
+
+    def test_path_traversal_rejected(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        _make_hook(outside, "evil.sh", "echo malicious")
+        config = {"hooks": {"post-run": [{"path": "../outside/evil.sh"}]}}
+        # Should not raise — hook is silently skipped
+        _run_post_run_hooks(config, repo_root, repo_root / "state", [], 0)
+
+    def test_missing_hook_file_skipped(self, tmp_path):
+        config = {"hooks": {"post-run": [{"path": "nonexistent.sh"}]}}
+        _run_post_run_hooks(config, tmp_path, tmp_path / "state", [], 0)
+
+    def test_zero_new_tags_reported(self, tmp_path):
+        out_file = tmp_path / "received.json"
+        hook = tmp_path / "capture.sh"
+        hook.write_text(f"#!/bin/sh\ncat > {out_file}\n")
+        hook.chmod(hook.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        config = {"hooks": {"post-run": [{"path": "capture.sh"}]}}
+        _run_post_run_hooks(config, tmp_path, tmp_path / "state", [], 0)
+        received = json.loads(out_file.read_text())
+        assert received["summary"]["newTagCount"] == 0
+        assert received["summary"]["totalImages"] == 0


### PR DESCRIPTION
## Summary

- Adds `_run_post_run_hooks()` — a new hook point that fires **once** after all images are processed (different contract from `post-image-check` which fires per-image)
- `cmd_check` now prints a job summary line (`N images checked, M new upstream tags`) to stderr after each run
- Writes the summary to `GITHUB_STEP_SUMMARY` when the env var is set
- Post-run hook payload includes `results`, `summary.totalImages`, `summary.newTagCount`, and `stateDir` so hooks can read all state files

## Test plan

- [x] 7 new unit tests in `test_hooks.py` (payload correctness, failure/timeout tolerance, path-traversal rejection)
- [x] 428 existing tests still pass

Part of [CAS-605](/CAS/issues/CAS-605). Companion PR in cascadeguard-data adds the `scan-count.py` hook that uses this hook point.