### PR TITLE
fix(check): force-push promotion branch when no open PR exists

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1841,7 +1841,8 @@ def _create_promotion_pr(
         )
 
         if is_gitlab:
-            _run_git(repo_root, ["push", "-u", "origin", branch])
+            push_args = ["push", "-u", "origin", branch] if existing_pr else ["push", "--force", "-u", "origin", branch]
+            _run_git(repo_root, push_args)
             if existing_pr:
                 _gitlab_api(
                     "POST",
@@ -1887,7 +1888,7 @@ def _create_promotion_pr(
             print(f"  PR #{existing_pr} updated for {base_image}: {new_digest[:16]}…", file=sys.stderr)
         else:
             # Create new GitHub PR
-            _run_git(repo_root, ["push", "-u", "origin", branch])
+            _run_git(repo_root, ["push", "--force", "-u", "origin", branch])
             pr_data, err = _github_api(
                 "POST",
                 f"https://api.github.com/repos/{gh_repo}/pulls",

--- a/app/app.py
+++ b/app/app.py
@@ -1691,10 +1691,10 @@ def _create_promotion_pr(
     if is_gitlab:
         gl_server = os.environ.get("CI_SERVER_URL", "https://gitlab.com").rstrip("/")
         gl_project = os.environ.get("CI_PROJECT_ID") or os.environ.get("CI_PROJECT_PATH", "")
-        gl_token = os.environ.get("CI_JOB_TOKEN") or os.environ.get("GITLAB_TOKEN", "")
+        gl_token = os.environ.get("GITLAB_TOKEN") or os.environ.get("CI_JOB_TOKEN", "")
         if not (gl_project and gl_token):
             print(
-                "Warning: CI_PROJECT_ID/CI_JOB_TOKEN not set — skipping MR creation",
+                "Warning: CI_PROJECT_ID/GITLAB_TOKEN/CI_JOB_TOKEN not set — skipping MR creation",
                 file=sys.stderr,
             )
             return [], []


### PR DESCRIPTION
## Summary

Two bugs causing the GitLab exemplar check job to fail:

**Bug 1: Non-fast-forward push on stale promotion branch**
When a promotion branch exists remotely but has no open MR (e.g. push succeeded in a prior run but MR creation failed with 401), the next check run recreates the branch from `main` and fails with a non-fast-forward push error. Fix: use `--force` for new-branch pushes (no `existing_pr`) on both GitLab and GitHub paths.

**Bug 2: CI_JOB_TOKEN insufficient for MR creation**
`_create_promotion_pr` was selecting `CI_JOB_TOKEN` over `GITLAB_TOKEN` for API calls. In GitLab projects with restricted job token scope, `CI_JOB_TOKEN` gets HTTP 401 on MR creation. Fix: prefer `GITLAB_TOKEN` (PAT) when available, fall back to `CI_JOB_TOKEN`.

**Verified:** GitLab exemplar scheduled check job [14102750932](https://gitlab.com/cascadeguard/cascadeguard-exemplar-web-argocd/-/jobs/14102750932) — **success**

## Test plan

- [x] Existing `test_promotion_pr_api.py` tests pass (git push is mocked)
- [x] GitLab exemplar check job passes end-to-end with fix pinned

Closes [CAS-595](/CAS/issues/CAS-595)