### PR TITLE
fix(cdk8s): upgrade pytest to >=9.0.3 (CVE-2025-71176)

### DIFF
--- a/cdk8s/pyproject.toml
+++ b/cdk8s/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=9.0.2",
+    "pytest>=9.0.3",
     "hypothesis>=6.0.0",
 ]
 

--- a/cdk8s/uv.lock
+++ b/cdk8s/uv.lock
@@ -32,7 +32,7 @@ requires-dist = [
     { name = "cdk8s", specifier = "~=2.68.0" },
     { name = "constructs", specifier = "~=10.4.3" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pyyaml" },
 ]
 provides-extras = ["dev"]
@@ -188,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -199,9 +199,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.130051Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `pytest` from `9.0.2` to `9.0.3` in `cdk8s/pyproject.toml` to fix CVE-2025-71176 (vulnerable tmpdir handling)
- Updates `cdk8s/uv.lock` with correct hashes from PyPI for pytest 9.0.3
- Resolves Dependabot alert #5

## Test plan

- [ ] CI passes (cdk8s synth + pytest)
- [ ] No pytest 9.0.2 references remain in lock file

Closes CAS-682