### PR TITLE
chore: dependabot sweep 2026-05 (safe CI bumps)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build and push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Dependabot Sweep — May 2026

Rolls up safe/minor CI Dependabot bumps. MAJOR artifact action upgrades held for separate review.

### Included
- `actions/setup-node` 6.3.0 → 6.4.0 (minor, #110)
- `docker/build-push-action` 7.0.0 → 7.1.0 (minor, #100)

### Held for separate PRs (MAJOR bumps)
| PR | Package | Change | Risk |
|---|---|---|---|
| #102 | actions/download-artifact | v4 → v8 | Breaking API |
| #101 | actions/upload-artifact | v4 → v7 | Breaking API |

Part of routine [CAS-695](/CAS/issues/CAS-695) weekly Dependabot sweep.